### PR TITLE
fix: Return defaultVariation when feature cannot be bucketed

### DIFF
--- a/examples/example-1/features/baz.yml
+++ b/examples/example-1/features/baz.yml
@@ -1,0 +1,27 @@
+description: Classic on/off switch
+tags:
+  - all
+
+defaultVariation: false
+
+bucketBy: userId
+
+variations:
+  - type: boolean
+    value: true
+    weight: 100
+  - type: boolean
+    value: false
+    weight: 0
+
+environments:
+  staging:
+    rules:
+      - key: "1"
+        segments: "*"
+        percentage: 100
+  production:
+    rules:
+      - key: "1"
+        segments: "*"
+        percentage: 80

--- a/examples/example-1/tests/baz.spec.yml
+++ b/examples/example-1/tests/baz.spec.yml
@@ -1,0 +1,20 @@
+tests:
+  - tag: all
+    environment: production
+    features:
+      - key: baz
+        assertions:
+          - at: 10
+            attributes:
+              country: nl
+            expectedVariation: true
+
+          - at: 70
+            attributes:
+              country: nl
+            expectedVariation: true
+
+          - at: 90
+            attributes:
+              country: nl
+            expectedVariation: false

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -146,7 +146,7 @@ export class FeaturevisorSDK {
       const variation = getBucketedVariation(feature, attributes, bucketValue, this.datafileReader);
 
       if (!variation) {
-        return undefined;
+        return feature.defaultVariation;
       }
 
       return variation.value;


### PR DESCRIPTION
Closes #24 