### PR TITLE
fix: use compare-versions package to reduce sdk bundle size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3692,6 +3692,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/compare-versions": {
+      "version": "6.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.0.0-rc.1.tgz",
+      "integrity": "sha512-cFhkjbGY1jLFWIV7KegECbfuyYPxSGvgGkdkfM+ibboQDoPwg2FRHm5BSNTOApiauRBzJIQH7qvOJs2sW5ueKQ=="
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -12529,33 +12534,8 @@
       "license": "MIT",
       "dependencies": {
         "@featurevisor/types": "^0.12.0",
-        "murmurhash": "^2.0.1",
-        "semver": "^7.3.8"
-      }
-    },
-    "packages/sdk/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/sdk/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "compare-versions": "^6.0.0-rc.1",
+        "murmurhash": "^2.0.1"
       }
     },
     "packages/site": {
@@ -13187,26 +13167,8 @@
       "version": "file:packages/sdk",
       "requires": {
         "@featurevisor/types": "^0.12.0",
-        "murmurhash": "^2.0.1",
-        "semver": "^7.3.8"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
+        "compare-versions": "*",
+        "murmurhash": "^2.0.1"
       }
     },
     "@featurevisor/site": {
@@ -15642,6 +15604,11 @@
           }
         }
       }
+    },
+    "compare-versions": {
+      "version": "6.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.0.0-rc.1.tgz",
+      "integrity": "sha512-cFhkjbGY1jLFWIV7KegECbfuyYPxSGvgGkdkfM+ibboQDoPwg2FRHm5BSNTOApiauRBzJIQH7qvOJs2sW5ueKQ=="
     },
     "concat-map": {
       "version": "0.0.1",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -43,7 +43,7 @@
   "license": "MIT",
   "dependencies": {
     "@featurevisor/types": "^0.12.0",
-    "murmurhash": "^2.0.1",
-    "semver": "^7.3.8"
+    "compare-versions": "^6.0.0-rc.1",
+    "murmurhash": "^2.0.1"
   }
 }

--- a/packages/sdk/src/conditions.ts
+++ b/packages/sdk/src/conditions.ts
@@ -1,11 +1,6 @@
-import { Attributes, Condition, PlainCondition } from "@featurevisor/types";
+import { compareVersions } from "compare-versions";
 
-import * as semverGt from "semver/functions/gt";
-import * as semverLt from "semver/functions/lt";
-import * as semverEq from "semver/functions/eq";
-import * as semverNeq from "semver/functions/neq";
-import * as semverGte from "semver/functions/gte";
-import * as semverLte from "semver/functions/lte";
+import { Attributes, Condition, PlainCondition } from "@featurevisor/types";
 
 export function conditionIsMatched(condition: PlainCondition, attributes: Attributes): boolean {
   const { attribute, operator, value } = condition;
@@ -36,17 +31,17 @@ export function conditionIsMatched(condition: PlainCondition, attributes: Attrib
     } else if (operator === "endsWith") {
       return valueInAttributes.endsWith(value);
     } else if (operator === "semverEquals") {
-      return semverEq(valueInAttributes, value);
+      return compareVersions(valueInAttributes, value) === 0;
     } else if (operator === "semverNotEquals") {
-      return semverNeq(valueInAttributes, value);
+      return compareVersions(valueInAttributes, value) !== 0;
     } else if (operator === "semverGreaterThan") {
-      return semverGt(valueInAttributes, value);
+      return compareVersions(valueInAttributes, value) === 1;
     } else if (operator === "semverGreaterThanOrEquals") {
-      return semverGte(valueInAttributes, value);
+      return compareVersions(valueInAttributes, value) >= 0;
     } else if (operator === "semverLessThan") {
-      return semverLt(valueInAttributes, value);
+      return compareVersions(valueInAttributes, value) === -1;
     } else if (operator === "semverLessThanOrEquals") {
-      return semverLte(valueInAttributes, value);
+      return compareVersions(valueInAttributes, value) <= 0;
     }
   } else if (typeof attributes[attribute] === "number" && typeof value === "number") {
     // numeric


### PR DESCRIPTION
Reduces SDK size to 20kB (5.6kB minified and gzipped)