### PR TITLE
fix: do not require variation type in Feature's YAML

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -22,13 +22,11 @@ bucketBy: userId
 defaultVariation: false
 
 variations:
-  - type: boolean
-    value: false
-    weight: 50
+  - value: true
+    weight: 100
 
-  - type: boolean
-    value: true
-    weight: 50
+  - value: false
+    weight: 0
 
 environments:
   staging:
@@ -44,7 +42,7 @@ environments:
         percentage: 100
 ```
 
-Quite a lot of things are happening there. We will go through each of properties from the snippet above in the following sections.
+Quite a lot of things are happening there. We will go through each of the properties from the snippet above in the following sections.
 
 ## Description
 
@@ -104,42 +102,43 @@ defaultVariation: false
 
 ## Variations
 
-A feature can have multiple variations. Each variation must have a different value.
+A feature can have multiple variations. Each variation must have a different value, but all variations must of the same type.
 
-Here, we have used simple boolean values for the variations with an equal 50-50 weight distribution:
+### Boolean flags
+
+Here, we have used simple boolean values for the variations:
 
 ```yml
 # ...
 variations:
-  - type: boolean
-    value: false
-    weight: 50
+  - value: true
+    weight: 100
 
-  - type: boolean
-    value: true
-    weight: 50
+  - value: false
+    weight: 0
 ```
 
-But we could have also have `string` type variations where number of total variations can be more than two:
+### A/B tests
+
+But we could have also used `string` type variations where number of total variations can be more than two:
 
 ```yml
 defaultVariation: control
 
 variations:
-  - type: string
-    value: control
+  - value: control
     weight: 50
 
-  - type: string
-    value: b
+  - value: b
     weight: 25
 
-  - type: string
-    value: c
+  - value: c
     weight: 25
 ```
 
 The sum of all variations' weights must be 100.
+
+You can have upto 2 decimal places for each weight.
 
 {% callout type="note" title="Control variation" %}
 In the world of experimentation, the default variation is usually called the `control` variation.
@@ -167,6 +166,8 @@ environments:
 
 Each environment is keyed by its name, as seen above with `staging` and `production` environments.
 
+The environment keys are based on your project configuration. Read more in [Configuration](/docs/configuration).
+
 ## Rules
 
 Each environment can have multiple rollout rules.
@@ -184,7 +185,7 @@ environments:
         percentage: 50
 
       - key: "2"
-        segments: "*"
+        segments: "*" # everyone
         percentage: 100
 ```
 
@@ -216,7 +217,7 @@ Targeting your audience is one of the most important things when rolling out fea
 
 ### Everyone
 
-If we wish to roll out a feature to all users, we can use the `*` wildcard in `segments` property:
+If we wish to roll out a feature to everyone, we can use the `*` wildcard in `segments` property:
 
 ```yml
 # ...
@@ -355,16 +356,14 @@ Then, we can assign values to the variables inside variations:
 ```yml
 # ...
 variations:
-  - type: boolean
-    value: false
-    weight: 50
-
-  - type: boolean
-    value: true
-    weight: 50
+  - value: true
+    weight: 100
     variables:
       - key: bgColor
         value: blue
+
+  - value: false
+    weight: 0
 ```
 
 If users are bucketed in the `true` variation, they will get the `bgColor` variable value of `blue`. Otherwise they will fall back to the default value of `red` as defined in the schema.
@@ -404,10 +403,8 @@ Or, you can override within variations:
 # ...
 variations:
   # ...
-
-  - type: boolean
-    value: true
-    weight: 50
+  - value: true
+    weight: 100
     variables:
       - key: bgColor
         value: blue
@@ -424,9 +421,8 @@ If you want to embed overriding conditions directly within variations:
 variations:
   # ...
 
-  - type: boolean
-    value: true
-    weight: 50
+  - value: true
+    weight: 100
     variables:
       - key: bgColor
         value: blue
@@ -453,9 +449,8 @@ variablesSchema:
 
 variations:
   # ...
-  - type: boolean
-    value: true
-    weight: 50
+  - value: true
+    weight: 100
     variables:
       - key: bgColor
         value: blue
@@ -472,9 +467,8 @@ variablesSchema:
 
 variations:
   # ...
-  - type: boolean
-    value: true
-    weight: 50
+  - value: true
+    weight: 100
     variables:
       - key: showSidebar
         value: true
@@ -491,9 +485,8 @@ variablesSchema:
 
 variations:
   # ...
-  - type: boolean
-    value: true
-    weight: 50
+  - value: true
+    weight: 100
     variables:
       - key: position
         value: 2
@@ -510,9 +503,8 @@ variablesSchema:
 
 variations:
   # ...
-  - type: boolean
-    value: true
-    weight: 50
+  - value: true
+    weight: 100
     variables:
       - key: amount
         value: 4.99
@@ -531,9 +523,8 @@ variablesSchema:
 
 variations:
   # ...
-  - type: boolean
-    value: true
-    weight: 50
+  - value: true
+    weight: 100
     variables:
       - key: acceptedCards
         value:
@@ -554,9 +545,8 @@ variablesSchema:
 
 variations:
   # ...
-  - type: boolean
-    value: true
-    weight: 50
+  - value: true
+    weight: 100
     variables:
       - key: hero
         value:
@@ -575,9 +565,8 @@ variablesSchema:
 
 variations:
   # ...
-  - type: boolean
-    value: true
-    weight: 50
+  - value: true
+    weight: 100
     variables:
       - key: hero
         value: '{"title": "Welcome to our website", "subtitle": "We are glad you are here"}'

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -118,14 +118,12 @@ defaultVariation: false
 
 # boolean flags have only two variations: true and false
 variations:
-  - type: boolean
-    value: true
+  - value: true
     weight: 100 # out of a total of 100
 
   # weight is 0 because it's boolean, and
   # we can control the rollout percentage from environment rules below
-  - type: boolean
-    value: false
+  - value: false
     weight: 0
 
 environments:
@@ -163,16 +161,13 @@ defaultVariation: light
 # three variations: light, dimmed, and dark.
 # sum of all weights must be 100
 variations:
-  - type: string
-    value: light
+  - value: light
     weight: 33.34
 
-  - type: string
-    value: dimmed
+  - value: dimmed
     weight: 33.33
 
-  - type: string
-    value: dark
+  - value: dark
     weight: 33.33
 
 environments:

--- a/examples/example-1/features/bar.yml
+++ b/examples/example-1/features/bar.yml
@@ -1,3 +1,4 @@
+description: Example with object variable type
 tags:
   - all
 
@@ -17,11 +18,9 @@ variablesSchema:
       alignment: center
 
 variations:
-  - type: string
-    value: control
+  - value: control
     weight: 33
-  - type: string
-    value: b
+  - value: b
     weight: 33
     variables:
       - key: hero
@@ -38,8 +37,7 @@ variations:
               title: Hero Title for B in DE or CH
               subtitle: Hero Subtitle for B in DE of CH
               alignment: center for B in DE or CH
-  - type: string
-    value: c
+  - value: c
     weight: 34
 
 environments:

--- a/examples/example-1/features/baz.yml
+++ b/examples/example-1/features/baz.yml
@@ -8,11 +8,9 @@ bucketBy: userId
 
 variations:
   - description: Enabled for all
-    type: boolean
     value: true
     weight: 100
   - description: Disabled for all
-    type: boolean
     value: false
     weight: 0
 

--- a/examples/example-1/features/foo.yml
+++ b/examples/example-1/features/foo.yml
@@ -18,11 +18,9 @@ variablesSchema:
     defaultValue: ""
 
 variations:
-  - type: boolean
-    value: false
+  - value: false
     weight: 50
-  - type: boolean
-    value: true
+  - value: true
     weight: 50
     variables:
       - key: bar

--- a/examples/example-1/features/qux.yml
+++ b/examples/example-1/features/qux.yml
@@ -12,17 +12,14 @@ variablesSchema:
     defaultValue: '{"foo": "bar"}'
 
 variations:
-  - type: string
-    value: control
+  - value: control
     weight: 33.34
-  - type: string
-    value: b
+  - value: b
     weight: 33.33
     variables:
       - key: fooConfig
         value: '{"foo": "bar b"}'
-  - type: string
-    value: c
+  - value: c
     weight: 33.33
 
 environments:

--- a/examples/example-1/features/sidebar.yml
+++ b/examples/example-1/features/sidebar.yml
@@ -21,11 +21,9 @@ variablesSchema:
     defaultValue: "Sidebar Title"
 
 variations:
-  - type: boolean
-    value: false
+  - value: false
     weight: 10
-  - type: boolean
-    value: true
+  - value: true
     weight: 90
     variables:
       - key: position

--- a/packages/core/src/builder.ts
+++ b/packages/core/src/builder.ts
@@ -144,7 +144,6 @@ export function buildDatafile(
         bucketBy: parsedFeature.bucketBy || projectConfig.defaultBucketBy,
         variations: parsedFeature.variations.map((variation: Variation) => {
           const mappedVariation: any = {
-            type: variation.type,
             value: variation.value,
           };
 

--- a/packages/core/src/traffic.spec.ts
+++ b/packages/core/src/traffic.spec.ts
@@ -11,12 +11,10 @@ describe("core: Traffic", function () {
       // parsed variations from YAML
       [
         {
-          type: "string",
           value: "on",
           weight: 100,
         },
         {
-          type: "string",
           value: "off",
           weight: 0,
         },
@@ -59,12 +57,10 @@ describe("core: Traffic", function () {
       // parsed variations from YAML
       [
         {
-          type: "string",
           value: "on",
           weight: 50,
         },
         {
-          type: "string",
           value: "off",
           weight: 50,
         },
@@ -107,17 +103,14 @@ describe("core: Traffic", function () {
       // parsed variations from YAML
       [
         {
-          type: "string",
           value: "yes",
           weight: 33.33,
         },
         {
-          type: "string",
           value: "no",
           weight: 33.33,
         },
         {
-          type: "string",
           value: "maybe",
           weight: 33.34,
         },
@@ -164,12 +157,10 @@ describe("core: Traffic", function () {
       // parsed variations from YAML
       [
         {
-          type: "string",
           value: "on",
           weight: 50,
         },
         {
-          type: "string",
           value: "off",
           weight: 50,
         },
@@ -250,12 +241,10 @@ describe("core: Traffic", function () {
       // parsed variations from YAML
       [
         {
-          type: "string",
           value: "on",
           weight: 50,
         },
         {
-          type: "string",
           value: "off",
           weight: 50,
         },
@@ -325,17 +314,14 @@ describe("core: Traffic", function () {
       // parsed variations from YAML
       [
         {
-          type: "string",
           value: "a",
           weight: 33.33,
         },
         {
-          type: "string",
           value: "b",
           weight: 33.33,
         },
         {
-          type: "string",
           value: "c",
           weight: 33.34,
         },
@@ -409,22 +395,18 @@ describe("core: Traffic", function () {
       // parsed variations from YAML
       [
         {
-          type: "string",
           value: "a",
           weight: 25,
         },
         {
-          type: "string",
           value: "b",
           weight: 25,
         },
         {
-          type: "string",
           value: "c",
           weight: 25,
         },
         {
-          type: "string",
           value: "d",
           weight: 25,
         },
@@ -502,12 +484,10 @@ describe("core: Traffic", function () {
       // parsed variations from YAML
       [
         {
-          type: "string",
           value: "a",
           weight: 50,
         },
         {
-          type: "string",
           value: "b",
           weight: 50,
         },
@@ -593,12 +573,10 @@ describe("core: Traffic", function () {
       // parsed variations from YAML
       [
         {
-          type: "string",
           value: "a",
           weight: 50,
         },
         {
-          type: "string",
           value: "b",
           weight: 50,
         },

--- a/packages/react/src/activateFeature.spec.tsx
+++ b/packages/react/src/activateFeature.spec.tsx
@@ -16,10 +16,7 @@ function getNewInstance() {
           key: "test",
           defaultVariation: false,
           bucketBy: "userId",
-          variations: [
-            { type: "boolean", value: true },
-            { type: "boolean", value: false },
-          ],
+          variations: [{ value: true }, { value: false }],
           traffic: [
             {
               key: "1",
@@ -41,12 +38,12 @@ function getNewInstance() {
   return sdk;
 }
 
-describe("react: activateFeature", function() {
-  test("should be a function", function() {
+describe("react: activateFeature", function () {
+  test("should be a function", function () {
     expect(activateFeature).toBeInstanceOf(Function);
   });
 
-  test("should return the variation", function() {
+  test("should return the variation", function () {
     function TestComponent() {
       const variation = activateFeature("test", { userId: "1" });
 

--- a/packages/react/src/useSdk.spec.tsx
+++ b/packages/react/src/useSdk.spec.tsx
@@ -16,10 +16,7 @@ function getNewInstance() {
           key: "test",
           defaultVariation: false,
           bucketBy: "userId",
-          variations: [
-            { type: "boolean", value: true },
-            { type: "boolean", value: false },
-          ],
+          variations: [{ value: true }, { value: false }],
           traffic: [
             {
               key: "1",

--- a/packages/react/src/useStatus.spec.tsx
+++ b/packages/react/src/useStatus.spec.tsx
@@ -16,10 +16,7 @@ function getNewInstance() {
           key: "test",
           defaultVariation: false,
           bucketBy: "userId",
-          variations: [
-            { type: "boolean", value: true },
-            { type: "boolean", value: false },
-          ],
+          variations: [{ value: true }, { value: false }],
           traffic: [
             {
               key: "1",

--- a/packages/react/src/useVariable.spec.tsx
+++ b/packages/react/src/useVariable.spec.tsx
@@ -16,14 +16,7 @@ function getNewInstance() {
           key: "test",
           defaultVariation: "control",
           bucketBy: "userId",
-          variations: [
-            { type: "string", value: "control" },
-            {
-              type: "string",
-              value: "b",
-            },
-            { type: "string", value: "c" },
-          ],
+          variations: [{ value: "control" }, { value: "b" }, { value: "c" }],
           traffic: [
             {
               key: "1",

--- a/packages/react/src/useVariation.spec.tsx
+++ b/packages/react/src/useVariation.spec.tsx
@@ -16,10 +16,7 @@ function getNewInstance() {
           key: "test",
           defaultVariation: false,
           bucketBy: "userId",
-          variations: [
-            { type: "boolean", value: true },
-            { type: "boolean", value: false },
-          ],
+          variations: [{ value: true }, { value: false }],
           traffic: [
             {
               key: "1",

--- a/packages/sdk/src/createInstance.spec.ts
+++ b/packages/sdk/src/createInstance.spec.ts
@@ -2,12 +2,12 @@ import { DatafileContent } from "@featurevisor/types";
 
 import { createInstance } from "./createInstance";
 
-describe("sdk: createInstance", function() {
-  it("should be a function", function() {
+describe("sdk: createInstance", function () {
+  it("should be a function", function () {
     expect(typeof createInstance).toEqual("function");
   });
 
-  it("should create instance with datafile content", function() {
+  it("should create instance with datafile content", function () {
     const sdk = createInstance({
       datafile: {
         schemaVersion: "1",
@@ -21,7 +21,7 @@ describe("sdk: createInstance", function() {
     expect(typeof sdk.getVariation).toEqual("function");
   });
 
-  it("should trigger onReady event once", function(done) {
+  it("should trigger onReady event once", function (done) {
     let readyCount = 0;
 
     const sdk = createInstance({
@@ -43,7 +43,7 @@ describe("sdk: createInstance", function() {
     }, 0);
   });
 
-  it("should intercept attributes", function() {
+  it("should intercept attributes", function () {
     let intercepted = false;
 
     const sdk = createInstance({
@@ -55,10 +55,7 @@ describe("sdk: createInstance", function() {
             key: "test",
             defaultVariation: false,
             bucketBy: "userId",
-            variations: [
-              { type: "boolean", value: true },
-              { type: "boolean", value: false },
-            ],
+            variations: [{ value: true }, { value: false }],
             traffic: [
               {
                 key: "1",
@@ -75,7 +72,7 @@ describe("sdk: createInstance", function() {
         attributes: [],
         segments: [],
       },
-      interceptAttributes: function(attributes) {
+      interceptAttributes: function (attributes) {
         intercepted = true;
 
         return {
@@ -92,7 +89,7 @@ describe("sdk: createInstance", function() {
     expect(intercepted).toEqual(true);
   });
 
-  it("should activate feature", function() {
+  it("should activate feature", function () {
     let activated = false;
 
     const sdk = createInstance({
@@ -104,10 +101,7 @@ describe("sdk: createInstance", function() {
             key: "test",
             defaultVariation: false,
             bucketBy: "userId",
-            variations: [
-              { type: "boolean", value: true },
-              { type: "boolean", value: false },
-            ],
+            variations: [{ value: true }, { value: false }],
             traffic: [
               {
                 key: "1",
@@ -124,7 +118,7 @@ describe("sdk: createInstance", function() {
         attributes: [],
         segments: [],
       },
-      onActivation: function(featureKey) {
+      onActivation: function (featureKey) {
         activated = true;
       },
     });
@@ -144,7 +138,7 @@ describe("sdk: createInstance", function() {
     expect(activatedVariation).toEqual(true);
   });
 
-  it("should refresh datafile", function(done) {
+  it("should refresh datafile", function (done) {
     let revision = 1;
     let refreshed = false;
     let updated = false;
@@ -158,10 +152,7 @@ describe("sdk: createInstance", function() {
             key: "test",
             defaultVariation: false,
             bucketBy: "userId",
-            variations: [
-              { type: "boolean", value: true },
-              { type: "boolean", value: false },
-            ],
+            variations: [{ value: true }, { value: false }],
             traffic: [
               {
                 key: "1",
@@ -186,8 +177,8 @@ describe("sdk: createInstance", function() {
 
     const sdk = createInstance({
       datafileUrl: "http://localhost:3000/datafile.json",
-      handleDatafileFetch: function(datafileUrl) {
-        return new Promise(function(resolve, reject) {
+      handleDatafileFetch: function (datafileUrl) {
+        return new Promise(function (resolve, reject) {
           resolve(getDatafileContent());
         });
       },
@@ -202,7 +193,7 @@ describe("sdk: createInstance", function() {
 
     expect(sdk.isReady()).toEqual(false);
 
-    setTimeout(function() {
+    setTimeout(function () {
       expect(refreshed).toEqual(true);
       expect(updated).toEqual(true);
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -151,7 +151,6 @@ export interface Variable {
 
 export interface Variation {
   description?: string; // only available in YAML
-  type: VariationType;
   value: VariationValue;
   weight?: Weight; // 0 to 100 (available from parsed YAML, but not in datafile)
   variables?: Variable[];


### PR DESCRIPTION
## Before

```yml
# ...

variations:
  - type: boolean
    value: true
    weight: 100
  - type: boolean
    value: false
    weight: 0
```

## After

```yml
# ...

variations:
  - value: true
    weight: 100
  - value: false
    weight: 0
```