### PR TITLE
fix: remove duplicate redundant types

### DIFF
--- a/packages/sdk/src/instance.ts
+++ b/packages/sdk/src/instance.ts
@@ -40,12 +40,6 @@ export interface Statuses {
   refreshInProgress: boolean;
 }
 
-export type Event = "ready" | "refresh" | "update" | "activation";
-
-interface Listeners {
-  [key: string]: Function[];
-}
-
 export interface InstanceOptions {
   configureBucketValue?: ConfigureBucketValue;
   datafile?: DatafileContent | string;


### PR DESCRIPTION
The deleted types exist already in `emitter.ts` file.