### PR TITLE
feat: state files are now per environment

### DIFF
--- a/examples/example-1/features/discount.yml
+++ b/examples/example-1/features/discount.yml
@@ -1,6 +1,7 @@
 description: Enable discount in checkout flow
 tags:
   - all
+  - checkout
 
 defaultVariation: false
 

--- a/examples/example-1/featurevisor.config.js
+++ b/examples/example-1/featurevisor.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   environments: ["staging", "production"],
-  tags: ["all"],
+  tags: ["all", "checkout"],
 };

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -76,7 +76,12 @@ async function main() {
       handler: function (options) {
         const projectConfig = requireAndGetProjectConfig(rootDirectoryPath);
 
-        buildProject(rootDirectoryPath, projectConfig);
+        try {
+          buildProject(rootDirectoryPath, projectConfig);
+        } catch (e) {
+          console.error(e);
+          process.exit(1);
+        }
       },
     })
     .example("$0 build", "build datafiles")

--- a/packages/core/src/builder.ts
+++ b/packages/core/src/builder.ts
@@ -384,7 +384,7 @@ export function buildProject(rootDirectoryPath, projectConfig: ProjectConfig) {
       mkdirp.sync(outputEnvironmentDirPath);
 
       const outputFilePath = getDatafilePath(projectConfig, environment, tag);
-      fs.writeFileSync(outputFilePath, JSON.stringify(datafileContent));
+      fs.writeFileSync(outputFilePath, JSON.stringify(datafileContent, null, 2));
       console.log(`     File generated: ${outputFilePath}`);
     }
 
@@ -392,6 +392,6 @@ export function buildProject(rootDirectoryPath, projectConfig: ProjectConfig) {
     if (!fs.existsSync(projectConfig.stateDirectoryPath)) {
       mkdirp.sync(projectConfig.stateDirectoryPath);
     }
-    fs.writeFileSync(existingStateFilePath, JSON.stringify(existingState));
+    fs.writeFileSync(existingStateFilePath, JSON.stringify(existingState, null, 2));
   }
 }

--- a/packages/core/src/builder.ts
+++ b/packages/core/src/builder.ts
@@ -364,7 +364,7 @@ export function buildProject(rootDirectoryPath, projectConfig: ProjectConfig) {
       mkdirp.sync(outputEnvironmentDirPath);
 
       const outputFilePath = getDatafilePath(projectConfig, environment, tag);
-      fs.writeFileSync(outputFilePath, JSON.stringify(datafileContent, null, 2));
+      fs.writeFileSync(outputFilePath, JSON.stringify(datafileContent));
       console.log(`     File generated: ${outputFilePath}`);
     }
 
@@ -372,6 +372,6 @@ export function buildProject(rootDirectoryPath, projectConfig: ProjectConfig) {
     if (!fs.existsSync(projectConfig.stateDirectoryPath)) {
       mkdirp.sync(projectConfig.stateDirectoryPath);
     }
-    fs.writeFileSync(existingStateFilePath, JSON.stringify(existingState, null, 2));
+    fs.writeFileSync(existingStateFilePath, JSON.stringify(existingState));
   }
 }

--- a/packages/core/src/builder.ts
+++ b/packages/core/src/builder.ts
@@ -208,32 +208,12 @@ export function buildDatafile(
 
           return mappedVariation;
         }),
-        traffic:
-          existingState.features[featureKey] &&
-          existingState.features[featureKey].revision === options.revision
-            ? // use as exists in state, since it's already been allocated
-              parsedFeature.environments[options.environment].rules.map((rule) => {
-                return {
-                  key: rule.key,
-                  segments:
-                    typeof rule.segments !== "string"
-                      ? JSON.stringify(rule.segments)
-                      : rule.segments,
-                  percentage: rule.percentage, // @TODO: remove this in next breaking semver
-                  variation: rule.variation,
-                  variables: rule.variables,
-                  allocation:
-                    existingState.features[featureKey].traffic.find((t) => t.key === rule.key)
-                      ?.allocation || [],
-                };
-              })
-            : // generate new traffic allocation
-              getTraffic(
-                parsedFeature.variations,
-                parsedFeature.environments[options.environment].rules,
-                existingState.features[featureKey],
-                featureRanges.get(featureKey) || [],
-              ),
+        traffic: getTraffic(
+          parsedFeature.variations,
+          parsedFeature.environments[options.environment].rules,
+          existingState.features[featureKey],
+          featureRanges.get(featureKey) || [],
+        ),
       };
 
       // update state in memory, so that next datafile build can use it (in case it contains the same feature)

--- a/packages/core/src/traffic.spec.ts
+++ b/packages/core/src/traffic.spec.ts
@@ -196,6 +196,7 @@ describe("core: Traffic", function () {
 
       // existing feature from previous release
       {
+        revision: "1",
         variations: [
           {
             value: "on",
@@ -304,6 +305,7 @@ describe("core: Traffic", function () {
 
       // existing feature from previous release
       {
+        revision: "1",
         variations: [
           {
             value: "on",
@@ -397,6 +399,7 @@ describe("core: Traffic", function () {
 
       // existing feature from previous release
       {
+        revision: "1",
         variations: [
           {
             value: "a",
@@ -502,6 +505,7 @@ describe("core: Traffic", function () {
 
       // existing feature from previous release
       {
+        revision: "1",
         variations: [
           {
             value: "a",
@@ -607,6 +611,7 @@ describe("core: Traffic", function () {
 
       // existing feature from previous release
       {
+        revision: "1",
         variations: [
           {
             value: "a",
@@ -720,6 +725,7 @@ describe("core: Traffic", function () {
 
       // existing feature from previous release
       {
+        revision: "1",
         variations: [
           {
             value: "a",

--- a/packages/core/src/traffic.ts
+++ b/packages/core/src/traffic.ts
@@ -95,7 +95,7 @@ export function getTraffic(
     const needsRebucketing =
       !existingTrafficRule || // new rule
       variationsChanged || // variations changed
-      rulePercentageDiff <= 0 || // percentage decreased
+      rulePercentageDiff < 0 || // percentage decreased
       rangesChanged; // belongs to a group, and group ranges changed
 
     let updatedAvailableRanges = JSON.parse(JSON.stringify(availableRanges));

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -9,7 +9,7 @@ export interface Attributes {
 export interface Attribute {
   archived?: boolean; // only available in YAML
   key: AttributeKey;
-  type: AttributeValue; // @TODO: fix it to be `string`
+  type: string;
   capture?: boolean;
 }
 
@@ -339,7 +339,7 @@ export interface Assertion {
 }
 
 export interface TestFeature {
-  key: string; // @TODO: use FeatureKey?
+  key: FeatureKey;
   assertions: Assertion[];
 }
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -9,7 +9,7 @@ export interface Attributes {
 export interface Attribute {
   archived?: boolean; // only available in YAML
   key: AttributeKey;
-  type: AttributeValue;
+  type: AttributeValue; // @TODO: fix it to be `string`
   capture?: boolean;
 }
 
@@ -302,6 +302,7 @@ export interface ParsedFeature {
  * with consistent bucketing
  */
 export interface ExistingFeature {
+  revision: string;
   variations: {
     // @TODO: use Exclude with Variation?
     value: VariationValue;
@@ -338,7 +339,7 @@ export interface Assertion {
 }
 
 export interface TestFeature {
-  key: string;
+  key: string; // @TODO: use FeatureKey?
   assertions: Assertion[];
 }
 


### PR DESCRIPTION
## Currently

Every time a datafile is built against environment/tag combination against a revision (version), it generates a corresponding state file.

Read about state files here: https://featurevisor.com/docs/state-files/

## Problem

It works well as long as there are no overlaps of features across multiple tags.

Meaning, as long as same feature does not belong to multiple tags.

It is still alright, as long as multiple tags are added to the feature when the feature is first created. But if a feature starts with one tag, and then another new tag is added to it much later, the bucketing info will not match anymore across multiple state files which are built against environment/tag combo and not against an environment alone.

## Solution

State files are now generated against a single environment only and not taking tags into account.

This makes sure that bucketing info remains consistent across all datafiles which are built on a per environment/tag combination.

## Impact

This will cause inconvenience if you are an existing user of Featurevisor, and have built datafiles for your features with rules that do not have a percentage value of `0` or `100`.

Building the project again will risk rebucketing your users.

To help avoid rebucketing your users, you can merge your state files into one naming them `./.featurevisor/existing-state-<environment>.json` files.

And then continue building datafiles with:

```
$ featurevisor build
```