### PR TITLE
feat: Linting based on available keys

### DIFF
--- a/examples/example-1/features/foo.yml
+++ b/examples/example-1/features/foo.yml
@@ -61,9 +61,9 @@ environments:
             - attribute: userId
               operator: equals
               value: "123"
-            - attribute: deviceId
+            - attribute: device
               operator: equals
-              value: "234"
+              value: "mobile"
         variation: true
         variables:
           bar: yoooooo

--- a/examples/example-1/features/sidebar.yml
+++ b/examples/example-1/features/sidebar.yml
@@ -31,16 +31,20 @@ variations:
       - key: color
         value: red
         overrides:
-          - segments: germany
+          - segments:
+              - germany
             value: yellow
-          - segments: japan
+          - segments:
+              - switzerland
             value: white
       - key: sections
         value: ["home", "about", "contact"]
         overrides:
-          - segments: germany
+          - segments:
+              - germany
             value: ["home", "about", "contact", "imprint"]
-          - segments: netherlands
+          - segments:
+              - netherlands
             value: ["home", "about", "contact", "bitterballen"]
 
 environments:

--- a/packages/core/src/linter.ts
+++ b/packages/core/src/linter.ts
@@ -166,7 +166,11 @@ export function getGroupJoiSchema(projectConfig: ProjectConfig, availableFeature
   return groupJoiSchema;
 }
 
-export function getFeatureJoiSchema(projectConfig: ProjectConfig, conditionsJoiSchema) {
+export function getFeatureJoiSchema(
+  projectConfig: ProjectConfig,
+  conditionsJoiSchema,
+  availableSegmentKeys: string[],
+) {
   const variationValueJoiSchema = Joi.alternatives().try(Joi.string(), Joi.number(), Joi.boolean());
   const variableValueJoiSchema = Joi.alternatives()
     .try(
@@ -192,7 +196,7 @@ export function getFeatureJoiSchema(projectConfig: ProjectConfig, conditionsJoiS
     )
     .allow("");
 
-  const plainGroupSegment = Joi.string();
+  const plainGroupSegment = Joi.string().valid("*", ...availableSegmentKeys);
 
   const andOrNotGroupSegment = Joi.alternatives()
     .try(
@@ -453,7 +457,11 @@ export async function lintProject(projectConfig: ProjectConfig): Promise<boolean
   // lint features
   console.log("\nLinting features...\n");
   const featureFilePaths = getYAMLFiles(path.join(projectConfig.featuresDirectoryPath));
-  const featureJoiSchema = getFeatureJoiSchema(projectConfig, conditionsJoiSchema);
+  const featureJoiSchema = getFeatureJoiSchema(
+    projectConfig,
+    conditionsJoiSchema,
+    availableSegmentKeys,
+  );
 
   for (const filePath of featureFilePaths) {
     const key = path.basename(filePath, ".yml");

--- a/packages/core/src/linter.ts
+++ b/packages/core/src/linter.ts
@@ -112,13 +112,13 @@ export function getSegmentJoiSchema(projectConfig: ProjectConfig, conditionsJoiS
   return segmentJoiSchema;
 }
 
-export function getGroupJoiSchema(projectConfig: ProjectConfig) {
+export function getGroupJoiSchema(projectConfig: ProjectConfig, availableFeatureKeys: string[]) {
   const groupJoiSchema = Joi.object({
     description: Joi.string().required(),
     slots: Joi.array()
       .items(
         Joi.object({
-          feature: Joi.string(),
+          feature: Joi.string().valid(...availableFeatureKeys),
           percentage: Joi.number().precision(3).min(0).max(100),
         }),
       )
@@ -427,7 +427,7 @@ export async function lintProject(projectConfig: ProjectConfig): Promise<boolean
   console.log("\nLinting groups...\n");
   if (fs.existsSync(projectConfig.groupsDirectoryPath)) {
     const groupFilePaths = getYAMLFiles(path.join(projectConfig.groupsDirectoryPath));
-    const groupJoiSchema = getGroupJoiSchema(projectConfig);
+    const groupJoiSchema = getGroupJoiSchema(projectConfig, availableFeatureKeys);
 
     for (const filePath of groupFilePaths) {
       const key = path.basename(filePath, ".yml");


### PR DESCRIPTION
Linting made stricter by checking against available keys.

- Only available Attribute keys are allowed in conditions inside Segments and Features
- Only available Feature keys are allowed in Groups' slots
- Only available Segment keys are allowed in Feature rules

Read more about it here: https://featurevisor.com/docs/linting-yamls/