### PR TITLE
feat: ranges in datafiles as tuples

### DIFF
--- a/packages/core/src/allocator.spec.ts
+++ b/packages/core/src/allocator.spec.ts
@@ -1,3 +1,4 @@
+import { RangeTuple } from "@featurevisor/types";
 import { getAllocation, getUpdatedAvailableRangesAfterFilling } from "./allocator";
 
 describe("core: allocator", function () {
@@ -7,7 +8,7 @@ describe("core: allocator", function () {
   });
 
   test("fills a single range fully", function () {
-    const availableRanges = [{ start: 0, end: 100 }];
+    const availableRanges = [[0, 100]] as RangeTuple[];
     const result = getAllocation(availableRanges, 100);
 
     expect(result).toEqual(availableRanges);
@@ -17,20 +18,20 @@ describe("core: allocator", function () {
   });
 
   test("fills a single range partially", function () {
-    const availableRanges = [{ start: 0, end: 100 }];
+    const availableRanges = [[0, 100]] as RangeTuple[];
     const result = getAllocation(availableRanges, 80);
 
-    expect(result).toEqual([{ start: 0, end: 80 }]);
+    expect(result).toEqual([[0, 80]]);
 
     const updatedAvailableRanges = getUpdatedAvailableRangesAfterFilling(availableRanges, 80);
-    expect(updatedAvailableRanges).toEqual([{ start: 80, end: 100 }]);
+    expect(updatedAvailableRanges).toEqual([[80, 100]]);
   });
 
   test("fills multiple ranges fully", function () {
     const availableRanges = [
-      { start: 0, end: 50 },
-      { start: 50, end: 100 },
-    ];
+      [0, 50],
+      [50, 100],
+    ] as RangeTuple[];
     const result = getAllocation(availableRanges, 100);
 
     expect(result).toEqual(availableRanges);
@@ -41,9 +42,9 @@ describe("core: allocator", function () {
 
   test("fills multiple ranges with breaks in between fully", function () {
     const availableRanges = [
-      { start: 0, end: 40 },
-      { start: 60, end: 100 },
-    ];
+      [0, 40],
+      [60, 100],
+    ] as RangeTuple[];
     const result = getAllocation(availableRanges, 80);
 
     expect(result).toEqual(availableRanges);
@@ -54,51 +55,51 @@ describe("core: allocator", function () {
 
   test("fills multiple ranges partially", function () {
     const availableRanges = [
-      { start: 0, end: 50 },
-      { start: 50, end: 100 },
-    ];
+      [0, 50],
+      [50, 100],
+    ] as RangeTuple[];
     const result = getAllocation(availableRanges, 80);
 
     expect(result).toEqual([
-      { start: 0, end: 50 },
-      { start: 50, end: 80 },
+      [0, 50],
+      [50, 80],
     ]);
 
     const updatedAvailableRanges = getUpdatedAvailableRangesAfterFilling(availableRanges, 80);
-    expect(updatedAvailableRanges).toEqual([{ start: 80, end: 100 }]);
+    expect(updatedAvailableRanges).toEqual([[80, 100]]);
   });
 
   test("fills multiple ranges with breaks in between partially", function () {
     const availableRanges = [
-      { start: 0, end: 40 },
-      { start: 60, end: 100 },
-    ];
+      [0, 40],
+      [60, 100],
+    ] as RangeTuple[];
     const result = getAllocation(availableRanges, 50);
 
     expect(result).toEqual([
-      { start: 0, end: 40 },
-      { start: 60, end: 70 },
+      [0, 40],
+      [60, 70],
     ]);
 
     const updatedAvailableRanges = getUpdatedAvailableRangesAfterFilling(availableRanges, 50);
-    expect(updatedAvailableRanges).toEqual([{ start: 70, end: 100 }]);
+    expect(updatedAvailableRanges).toEqual([[70, 100]]);
   });
 
   test("fills multiple ranges with breaks in between partially, with 3 range items", function () {
     const availableRanges = [
-      { start: 0, end: 30 },
-      { start: 60, end: 70 },
-      { start: 90, end: 95 },
-    ];
+      [0, 30],
+      [60, 70],
+      [90, 95],
+    ] as RangeTuple[];
     const result = getAllocation(availableRanges, 42);
 
     expect(result).toEqual([
-      { start: 0, end: 30 },
-      { start: 60, end: 70 },
-      { start: 90, end: 92 },
+      [0, 30],
+      [60, 70],
+      [90, 92],
     ]);
 
     const updatedAvailableRanges = getUpdatedAvailableRangesAfterFilling(availableRanges, 42);
-    expect(updatedAvailableRanges).toEqual([{ start: 92, end: 95 }]);
+    expect(updatedAvailableRanges).toEqual([[92, 95]]);
   });
 });

--- a/packages/core/src/allocator.ts
+++ b/packages/core/src/allocator.ts
@@ -1,4 +1,5 @@
 import { Range, Percentage } from "@featurevisor/types";
+import { getStartEndFromRange } from "@featurevisor/sdk";
 
 export function getAllocation(availableRanges: Range[], fill: Percentage): Range[] {
   const result: Range[] = [];
@@ -7,11 +8,10 @@ export function getAllocation(availableRanges: Range[], fill: Percentage): Range
   let i = 0;
   while (remaining > 0 && i < availableRanges.length) {
     const range = availableRanges[i];
-    const rangeFill = Math.min(remaining, range.end - range.start);
-    result.push({
-      start: range.start,
-      end: range.start + rangeFill,
-    });
+    const [start, end] = getStartEndFromRange(range);
+
+    const rangeFill = Math.min(remaining, end - start);
+    result.push([start, start + rangeFill]);
     remaining -= rangeFill;
     i++;
   }
@@ -29,12 +29,10 @@ export function getUpdatedAvailableRangesAfterFilling(
   let i = 0;
   while (remaining > 0 && i < availableRanges.length) {
     const range = availableRanges[i];
-    const rangeFill = Math.min(remaining, range.end - range.start);
-    if (rangeFill < range.end - range.start) {
-      result.push({
-        start: range.start + rangeFill,
-        end: range.end,
-      });
+    const [start, end] = getStartEndFromRange(range);
+    const rangeFill = Math.min(remaining, end - start);
+    if (rangeFill < end - start) {
+      result.push([start + rangeFill, end]);
     }
     remaining -= rangeFill;
     i++;

--- a/packages/core/src/builder.ts
+++ b/packages/core/src/builder.ts
@@ -87,10 +87,7 @@ export function getFeatureRanges(projectConfig: ProjectConfig): Map<FeatureKey, 
           const start = isFirstSlot ? accumulatedPercentage : accumulatedPercentage + 1;
           const end = accumulatedPercentage + slot.percentage * 1000;
 
-          featureRangesForFeature.push({
-            start,
-            end,
-          });
+          featureRangesForFeature.push([start, end]);
 
           featureRanges.set(slot.feature, featureRangesForFeature);
         }

--- a/packages/core/src/traffic.spec.ts
+++ b/packages/core/src/traffic.spec.ts
@@ -41,10 +41,7 @@ describe("core: Traffic", function () {
           {
             variation: "on",
             percentage: 80000,
-            range: {
-              start: 0,
-              end: 80000,
-            },
+            range: [0, 80000],
           },
         ],
       },
@@ -87,18 +84,12 @@ describe("core: Traffic", function () {
           {
             variation: "on",
             percentage: 40000,
-            range: {
-              start: 0,
-              end: 40000,
-            },
+            range: [0, 40000],
           },
           {
             variation: "off",
             percentage: 40000,
-            range: {
-              start: 40000,
-              end: 80000,
-            },
+            range: [40000, 80000],
           },
         ],
       },
@@ -145,26 +136,17 @@ describe("core: Traffic", function () {
           {
             variation: "yes",
             percentage: 33330,
-            range: {
-              start: 0,
-              end: 33330,
-            },
+            range: [0, 33330],
           },
           {
             variation: "no",
             percentage: 33330,
-            range: {
-              start: 33330,
-              end: 66660,
-            },
+            range: [33330, 66660],
           },
           {
             variation: "maybe",
             percentage: 33340,
-            range: {
-              start: 66660,
-              end: 100000,
-            },
+            range: [66660, 100000],
           },
         ],
       },
@@ -215,18 +197,12 @@ describe("core: Traffic", function () {
               {
                 variation: "on",
                 percentage: 40000,
-                range: {
-                  start: 0,
-                  end: 40000,
-                },
+                range: [0, 40000],
               },
               {
                 variation: "off",
                 percentage: 40000,
-                range: {
-                  start: 40000,
-                  end: 80000,
-                },
+                range: [40000, 80000],
               },
             ],
           },
@@ -244,36 +220,24 @@ describe("core: Traffic", function () {
           {
             variation: "on",
             percentage: 40000,
-            range: {
-              start: 0,
-              end: 40000,
-            },
+            range: [0, 40000],
           },
           {
             variation: "off",
             percentage: 40000,
-            range: {
-              start: 40000,
-              end: 80000,
-            },
+            range: [40000, 80000],
           },
 
           // new
           {
             variation: "on",
             percentage: 5000,
-            range: {
-              start: 80000,
-              end: 85000,
-            },
+            range: [80000, 85000],
           },
           {
             variation: "off",
             percentage: 5000,
-            range: {
-              start: 85000,
-              end: 90000,
-            },
+            range: [85000, 90000],
           },
         ],
       },
@@ -324,18 +288,12 @@ describe("core: Traffic", function () {
               {
                 variation: "on",
                 percentage: 40000,
-                range: {
-                  start: 0,
-                  end: 40000,
-                },
+                range: [0, 40000],
               },
               {
                 variation: "off",
                 percentage: 40000,
-                range: {
-                  start: 40000,
-                  end: 80000,
-                },
+                range: [40000, 80000],
               },
             ],
           },
@@ -352,18 +310,12 @@ describe("core: Traffic", function () {
           {
             variation: "on",
             percentage: 35000,
-            range: {
-              start: 0,
-              end: 35000,
-            },
+            range: [0, 35000],
           },
           {
             variation: "off",
             percentage: 35000,
-            range: {
-              start: 35000,
-              end: 70000,
-            },
+            range: [35000, 70000],
           },
         ],
       },
@@ -418,18 +370,12 @@ describe("core: Traffic", function () {
               {
                 variation: "a",
                 percentage: 40000,
-                range: {
-                  start: 0,
-                  end: 40000,
-                },
+                range: [0, 40000],
               },
               {
                 variation: "b",
                 percentage: 40000,
-                range: {
-                  start: 40000,
-                  end: 80000,
-                },
+                range: [40000, 80000],
               },
             ],
           },
@@ -446,26 +392,17 @@ describe("core: Traffic", function () {
           {
             variation: "a",
             percentage: 29997,
-            range: {
-              start: 0,
-              end: 29997,
-            },
+            range: [0, 29997],
           },
           {
             variation: "b",
             percentage: 29997,
-            range: {
-              start: 29997,
-              end: 59994,
-            },
+            range: [29997, 59994],
           },
           {
             variation: "c",
             percentage: 30006,
-            range: {
-              start: 59994,
-              end: 90000,
-            },
+            range: [59994, 90000],
           },
         ],
       },
@@ -524,18 +461,12 @@ describe("core: Traffic", function () {
               {
                 variation: "a",
                 percentage: 40000,
-                range: {
-                  start: 0,
-                  end: 40000,
-                },
+                range: [0, 40000],
               },
               {
                 variation: "b",
                 percentage: 40000,
-                range: {
-                  start: 40000,
-                  end: 80000,
-                },
+                range: [40000, 80000],
               },
             ],
           },
@@ -552,34 +483,22 @@ describe("core: Traffic", function () {
           {
             variation: "a",
             percentage: 25000,
-            range: {
-              start: 0,
-              end: 25000,
-            },
+            range: [0, 25000],
           },
           {
             variation: "b",
             percentage: 25000,
-            range: {
-              start: 25000,
-              end: 50000,
-            },
+            range: [25000, 50000],
           },
           {
             variation: "c",
             percentage: 25000,
-            range: {
-              start: 50000,
-              end: 75000,
-            },
+            range: [50000, 75000],
           },
           {
             variation: "d",
             percentage: 25000,
-            range: {
-              start: 75000,
-              end: 100000,
-            },
+            range: [75000, 100000],
           },
         ],
       },
@@ -638,34 +557,22 @@ describe("core: Traffic", function () {
               {
                 variation: "a",
                 percentage: 25000,
-                range: {
-                  start: 0,
-                  end: 25000,
-                },
+                range: [0, 25000],
               },
               {
                 variation: "b",
                 percentage: 25000,
-                range: {
-                  start: 25000,
-                  end: 50000,
-                },
+                range: [25000, 50000],
               },
               {
                 variation: "c",
                 percentage: 25000,
-                range: {
-                  start: 50000,
-                  end: 75000,
-                },
+                range: [50000, 75000],
               },
               {
                 variation: "d",
                 percentage: 25000,
-                range: {
-                  start: 75000,
-                  end: 100000,
-                },
+                range: [75000, 100000],
               },
             ],
           },
@@ -682,18 +589,12 @@ describe("core: Traffic", function () {
           {
             variation: "a",
             percentage: 50000,
-            range: {
-              start: 0,
-              end: 50000,
-            },
+            range: [0, 50000],
           },
           {
             variation: "b",
             percentage: 50000,
-            range: {
-              start: 50000,
-              end: 100000,
-            },
+            range: [50000, 100000],
           },
         ],
       },
@@ -752,34 +653,22 @@ describe("core: Traffic", function () {
               {
                 variation: "a",
                 percentage: 25000,
-                range: {
-                  start: 0,
-                  end: 25000,
-                },
+                range: [0, 25000],
               },
               {
                 variation: "b",
                 percentage: 25000,
-                range: {
-                  start: 25000,
-                  end: 50000,
-                },
+                range: [25000, 50000],
               },
               {
                 variation: "c",
                 percentage: 25000,
-                range: {
-                  start: 50000,
-                  end: 75000,
-                },
+                range: [50000, 75000],
               },
               {
                 variation: "d",
                 percentage: 25000,
-                range: {
-                  start: 75000,
-                  end: 100000,
-                },
+                range: [75000, 100000],
               },
             ],
           },
@@ -796,18 +685,12 @@ describe("core: Traffic", function () {
           {
             variation: "a",
             percentage: 40000,
-            range: {
-              start: 0,
-              end: 40000,
-            },
+            range: [0, 40000],
           },
           {
             variation: "b",
             percentage: 40000,
-            range: {
-              start: 40000,
-              end: 80000,
-            },
+            range: [40000, 80000],
           },
         ],
       },

--- a/packages/core/src/traffic.ts
+++ b/packages/core/src/traffic.ts
@@ -1,5 +1,13 @@
-import { Rule, ExistingFeature, Traffic, Variation, Range, Percentage } from "@featurevisor/types";
-import { MAX_BUCKETED_NUMBER } from "@featurevisor/sdk";
+import {
+  Rule,
+  ExistingFeature,
+  Traffic,
+  Variation,
+  Range,
+  Percentage,
+  RangeTuple,
+} from "@featurevisor/types";
+import { MAX_BUCKETED_NUMBER, getStartEndFromRange } from "@featurevisor/sdk";
 
 import { getAllocation, getUpdatedAvailableRangesAfterFilling } from "./allocator";
 
@@ -62,7 +70,7 @@ export function getTraffic(
 
   // @TODO: may be pass from builder directly?
   const availableRanges =
-    ranges && ranges.length > 0 ? ranges : [{ start: 0, end: MAX_BUCKETED_NUMBER }];
+    ranges && ranges.length > 0 ? ranges : ([[0, MAX_BUCKETED_NUMBER]] as RangeTuple[]);
 
   parsedRules.forEach(function (parsedRule) {
     const rulePercentage = parsedRule.percentage; // 0 - 100
@@ -113,10 +121,7 @@ export function getTraffic(
         const result = {
           variation,
           percentage, // @TODO remove it in next breaking semver
-          range: range || {
-            start: lastEnd,
-            end: percentage,
-          },
+          range: range ? getStartEndFromRange(range) : ([lastEnd, percentage] as RangeTuple),
         };
 
         existingSum += percentage || 0;

--- a/packages/sdk/src/feature.ts
+++ b/packages/sdk/src/feature.ts
@@ -6,12 +6,25 @@ import {
   Variation,
   VariableValue,
   Force,
+  RangeObject,
+  RangeTuple,
 } from "@featurevisor/types";
 import { DatafileReader } from "./datafileReader";
 import { allGroupSegmentsAreMatched } from "./segments";
 import { allConditionsAreMatched } from "./conditions";
 import { VariableSchema } from "@featurevisor/types/src";
 import { Logger } from "./logger";
+
+// @TODO: remove this function in next breaking semver
+export function getStartEndFromRange(range: unknown): RangeTuple {
+  if (Array.isArray(range)) {
+    return range as RangeTuple;
+  }
+
+  const rangeObject = range as RangeObject;
+
+  return [rangeObject.start, rangeObject.end];
+}
 
 /**
  * Traffic
@@ -25,11 +38,9 @@ export function getMatchedAllocation(
     traffic.allocation.length > 0 && typeof traffic.allocation[0].range === "undefined"; // @TODO: remove it in next breaking semver
 
   for (const allocation of traffic.allocation) {
-    if (
-      allocation.range &&
-      allocation.range.start <= bucketValue &&
-      allocation.range.end >= bucketValue
-    ) {
+    const [start, end] = getStartEndFromRange(allocation.range);
+
+    if (allocation.range && start <= bucketValue && end >= bucketValue) {
       return allocation;
     }
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,3 +1,6 @@
 export * from "./bucket";
 export * from "./instance";
 export * from "./logger";
+
+// @TODO: remove this in next breaking semver
+export { getStartEndFromRange } from "./feature";

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -199,10 +199,15 @@ export type BucketValue = number; // 0 to 100,000 (100% * 1000 to include three 
  */
 export type Percentage = number; // 0 to 100,000 (100% * 1000 to include three decimal places in same integer)
 
-export interface Range {
+// @TODO: remove this in next breaking semver
+export interface RangeObject {
   start: Percentage; // 0 to 100k
   end: Percentage; // 0 to 100k
 }
+
+export type RangeTuple = [Percentage, Percentage]; // 0 to 100k
+
+export type Range = RangeObject | RangeTuple;
 
 export interface Allocation {
   variation: VariationValue;


### PR DESCRIPTION
## Before

Generated datafiles would contain bucketed range info in this shape:

```js
{
  start: 0,
  end: 100000
}
```

With more and more features and their bucketed ranges, it will grow big over time.

## After

Instead of objects, they are now expressed as tuples which will have a positive impact in generated datafile going foward reducing its size.

```js
[0, 100000]
```

## Impact

SDK is kept backwards compatible so it won't break your application.

You are advised to updated to latest SDK first, before generating new datafiles with latest version of Featurevisor CLI.