### PR TITLE
feat: make bucketing key configurable

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -91,6 +91,16 @@ bucketBy:
   - userId
 ```
 
+If you want to bucket users against first available attribute only, you can do as follows:
+
+```yml
+# ...
+bucketBy:
+  or:
+    - userId
+    - deviceId
+```
+
 ## Default variation
 
 If no rollout rules are matched for the user, Featurevisor SDKs will fall back to the default variation as set in `defaultVariation`.

--- a/packages/core/src/linter.ts
+++ b/packages/core/src/linter.ts
@@ -271,7 +271,20 @@ export function getFeatureJoiSchema(
 
     defaultVariation: variationValueJoiSchema,
 
-    bucketBy: Joi.alternatives().try(Joi.string(), Joi.array().items(Joi.string())).required(),
+    bucketBy: Joi.alternatives()
+      .try(
+        // plain
+        Joi.string(),
+
+        // and
+        Joi.array().items(Joi.string()),
+
+        // or
+        Joi.object({
+          or: Joi.array().items(Joi.string()),
+        }),
+      )
+      .required(),
 
     variablesSchema: Joi.array()
       .items(

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -8,6 +8,7 @@ Visit [https://featurevisor.com/docs/sdks/](https://featurevisor.com/docs/sdks/)
 - [Usage](#usage)
 - [Options](#options)
   - [`bucketKeySeparator`](#bucketkeyseparator)
+  - [`configureBucketKey`](#configurebucketkey)
   - [`configureBucketValue`](#configurebucketvalue)
   - [`datafile`](#datafile)
   - [`datafileUrl`](#datafileurl)
@@ -59,6 +60,21 @@ Options you can pass when creating Featurevisor SDK instance:
 - Type: `string`
 - Required: no
 - Defaults to: `.`
+
+### `configureBucketKey`
+
+- Type: `function`
+- Required: no
+
+Use it to take over bucketing key generation process.
+
+```js
+const sdk = createInstance({
+  configureBucketKey: (feature, attributes, bucketKey) => {
+    return bucketKey;
+  }
+});
+```
 
 ### `configureBucketValue`
 

--- a/packages/sdk/src/instance.spec.ts
+++ b/packages/sdk/src/instance.spec.ts
@@ -44,6 +44,147 @@ describe("sdk: instance", function () {
     }, 0);
   });
 
+  it("should configure plain bucketBy", function () {
+    let capturedBucketKey = "";
+
+    const sdk = createInstance({
+      datafile: {
+        schemaVersion: "1",
+        revision: "1.0",
+        features: [
+          {
+            key: "test",
+            defaultVariation: false,
+            bucketBy: "userId",
+            variations: [{ value: true }, { value: false }],
+            traffic: [
+              {
+                key: "1",
+                segments: "*",
+                percentage: 100000,
+                allocation: [
+                  { variation: true, range: { start: 0, end: 100000 } },
+                  { variation: false, range: { start: 0, end: 0 } },
+                ],
+              },
+            ],
+          },
+        ],
+        attributes: [],
+        segments: [],
+      },
+      configureBucketKey: function (feature, attributes, bucketKey) {
+        capturedBucketKey = bucketKey;
+
+        return bucketKey;
+      },
+    });
+
+    const variation = sdk.getVariation("test", {
+      userId: "123",
+    });
+
+    expect(variation).toEqual(true);
+    expect(capturedBucketKey).toEqual("123.test");
+  });
+
+  it("should configure and bucketBy", function () {
+    let capturedBucketKey = "";
+
+    const sdk = createInstance({
+      datafile: {
+        schemaVersion: "1",
+        revision: "1.0",
+        features: [
+          {
+            key: "test",
+            defaultVariation: false,
+            bucketBy: ["userId", "organizationId"],
+            variations: [{ value: true }, { value: false }],
+            traffic: [
+              {
+                key: "1",
+                segments: "*",
+                percentage: 100000,
+                allocation: [
+                  { variation: true, range: { start: 0, end: 100000 } },
+                  { variation: false, range: { start: 0, end: 0 } },
+                ],
+              },
+            ],
+          },
+        ],
+        attributes: [],
+        segments: [],
+      },
+      configureBucketKey: function (feature, attributes, bucketKey) {
+        capturedBucketKey = bucketKey;
+
+        return bucketKey;
+      },
+    });
+
+    const variation = sdk.getVariation("test", {
+      userId: "123",
+      organizationId: "456",
+    });
+
+    expect(variation).toEqual(true);
+    expect(capturedBucketKey).toEqual("123.456.test");
+  });
+
+  it("should configure or bucketBy", function () {
+    let capturedBucketKey = "";
+
+    const sdk = createInstance({
+      datafile: {
+        schemaVersion: "1",
+        revision: "1.0",
+        features: [
+          {
+            key: "test",
+            defaultVariation: false,
+            bucketBy: { or: ["userId", "deviceId"] },
+            variations: [{ value: true }, { value: false }],
+            traffic: [
+              {
+                key: "1",
+                segments: "*",
+                percentage: 100000,
+                allocation: [
+                  { variation: true, range: { start: 0, end: 100000 } },
+                  { variation: false, range: { start: 0, end: 0 } },
+                ],
+              },
+            ],
+          },
+        ],
+        attributes: [],
+        segments: [],
+      },
+      configureBucketKey: function (feature, attributes, bucketKey) {
+        capturedBucketKey = bucketKey;
+
+        return bucketKey;
+      },
+    });
+
+    expect(
+      sdk.getVariation("test", {
+        userId: "123",
+        deviceId: "456",
+      }),
+    ).toEqual(true);
+    expect(capturedBucketKey).toEqual("123.test");
+
+    expect(
+      sdk.getVariation("test", {
+        deviceId: "456",
+      }),
+    ).toEqual(true);
+    expect(capturedBucketKey).toEqual("456.test");
+  });
+
   it("should intercept attributes", function () {
     let intercepted = false;
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -226,7 +226,13 @@ export interface Traffic {
   allocation: Allocation[];
 }
 
-export type BucketBy = AttributeKey | AttributeKey[]; // @TODO: have first available attribute as well?
+export type PlainBucketBy = AttributeKey;
+export type AndBucketBy = AttributeKey[];
+export interface OrBucketBy {
+  or: AttributeKey[];
+}
+export type BucketBy = PlainBucketBy | AndBucketBy | OrBucketBy;
+
 export interface Feature {
   key: FeatureKey;
   // @TODO: introduce new `parent` key?


### PR DESCRIPTION
## What's done

Feature's `bucketBy` property can now accept `or` conditional attribute keys.

And a new `configureBucketKey` option is added, which also helps with testing.

## Docs

The `bucketBy` property is used to determine how the feature will be bucketed. Meaning, how the variation of a feature is assigned to a user.

```yml
# ...
bucketBy: userId
```

Given we used `userId` attribute as the `bucketBy` value, it means no matter which application or device the user is using, as long as the `userId` value is the same, the same variation of the feature will be consistently assigned to that particular user.

If you want to bucket users against multiple attributes together, you can do as follows:

```yml
# ...
bucketBy:
  - organizationId
  - userId
```

If you want to bucket users against first available attribute only, you can do as follows:

```yml
# ...
bucketBy:
  or:
    - userId
    - deviceId
```