### PR TITLE
feat: omit empty ranges in datafile

### DIFF
--- a/packages/core/src/traffic.ts
+++ b/packages/core/src/traffic.ts
@@ -140,6 +140,14 @@ export function getTraffic(
       );
     });
 
+    traffic.allocation = traffic.allocation.filter((a) => {
+      if (a.range && a.range[0] === a.range[1]) {
+        return false;
+      }
+
+      return true;
+    });
+
     result.push(traffic);
   });
 


### PR DESCRIPTION
## What's done

Ranges like `[0, 0]` will not appear in datafiles any more, reducing its size.

Think of variations with weights of `0`.