### PR TITLE
feat: do not allow "variation" as variable key

### DIFF
--- a/packages/core/src/linter.ts
+++ b/packages/core/src/linter.ts
@@ -289,7 +289,7 @@ export function getFeatureJoiSchema(
     variablesSchema: Joi.array()
       .items(
         Joi.object({
-          key: Joi.string(),
+          key: Joi.string().disallow("variation"),
           type: Joi.string().valid(
             "string",
             "integer",


### PR DESCRIPTION
This will fail linting if anyone names any of their variable keys `variation`, to help avoid any confusion.