### PR TITLE
docs: Added Piral to MF Documentation

### DIFF
--- a/docs/use-cases/microfrontends.md
+++ b/docs/use-cases/microfrontends.md
@@ -37,6 +37,7 @@ There are several frameworks and tools that can help achieve this architecture, 
 
 - [Module federation](https://webpack.js.org/concepts/module-federation/) (webpack)
 - [single-spa](https://single-spa.js.org/)
+- [Piral](https://piral.io/)
 
 ## Your application
 


### PR DESCRIPTION
I'd potentially also add a section that featurevisor could be consumed from a microfrontend discovery service, too. This way, you would not need to consume it within a microfrontend (but, of course, for whatever reason one might still do that).

In many cases just disabling or enabling the microfrontend for certain users might be sufficient and the most consistent way of dealing with functionality. (One of many examples: https://youtu.be/Oc2ohxEpUpA?t=2176)