### PR TITLE
feat: restore state files

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -69,6 +69,16 @@ $ featurevisor test
 
 Learn more in [Testing](/docs/testing).
 
+## Restore state files
+
+Building datafiles also generates [state files](/docs/state-files).
+
+To restore them to last known state in Git, run:
+
+```
+$ featurevisor restore
+```
+
 ## Generate static site
 
 Build the site:

--- a/docs/state-files.md
+++ b/docs/state-files.md
@@ -3,7 +3,7 @@ title: State files
 description: Learn about Featurevisor state files
 ---
 
-When you build your datafiles, Featurevisor generates some additional JSON files that are used to keep track of the most recently delpoyed build of your project. These files are called state files. {% .lead %}
+When you build your datafiles, Featurevisor generates some additional JSON files that are used to keep track of the most recently deployed build of your project. These files are called state files. {% .lead %}
 
 ## Location
 
@@ -13,6 +13,16 @@ You don't have to deal with them directly ever, but they contain valuable rollou
 
 ## Committing state files
 
-It is recommended that you keep your state files in the git repository.
+It is recommended that you keep your state files in the Git repository, but not manually commit them yourself when sending Pull Requests.
 
 We will learn more about it in [Deployment](/docs/deployment).
+
+## Restoring state files
+
+If you have already built your datafiles, you can restore the state files to the last known state in Git by running:
+
+```
+$ featurevisor restore
+```
+
+This will only work if the state files already exist in the Git repository.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,6 +15,7 @@ import {
   generateCodeForProject,
   BuildCLIOptions,
   GenerateCodeCLIOptions,
+  restoreProject,
 } from "@featurevisor/core";
 
 process.on("unhandledRejection", (reason, p) => {
@@ -88,6 +89,21 @@ async function main() {
       },
     })
     .example("$0 build", "build datafiles")
+
+    .command({
+      command: "restore",
+      handler: function (options) {
+        const projectConfig = requireAndGetProjectConfig(rootDirectoryPath);
+
+        try {
+          restoreProject(rootDirectoryPath, projectConfig);
+        } catch (e) {
+          console.error(e.message);
+          process.exit(1);
+        }
+      },
+    })
+    .example("$0 restore", "restore state files")
 
     .command({
       command: "test",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,3 +5,4 @@ export * from "./tester";
 export * from "./init";
 export * from "./site";
 export * from "./generate-code";
+export * from "./restore";

--- a/packages/core/src/restore.ts
+++ b/packages/core/src/restore.ts
@@ -1,0 +1,21 @@
+import * as path from "path";
+import { execSync } from "child_process";
+
+import { ProjectConfig } from "./config";
+
+export function restoreProject(rootDirectoryPath, projectConfig: ProjectConfig) {
+  const relativeStateDirPath = path.relative(rootDirectoryPath, projectConfig.stateDirectoryPath);
+  const cmd = `git checkout -- ${relativeStateDirPath}${path.sep}`;
+
+  try {
+    const output = execSync(cmd, {
+      cwd: rootDirectoryPath,
+    });
+
+    console.log("State files restored successfully.");
+  } catch (e) {
+    console.log("error:", e.message);
+
+    throw new Error("Failed to restore state files.");
+  }
+}


### PR DESCRIPTION
New CLI command introduced:

```
$ featurevisor restore
```

Equivalent of:

```
$ git checkout -- .featurevisor/
```

It will automatically use the state files directory path based on `featurevisor.config.js`.