### PR TITLE
feat: renamed Attributes (object) to Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,16 +139,13 @@ const sdk = createInstance({
 });
 
 // Evaluate a feature flag
-const isFeatureEnabled = sdk.getVariation(
-  // feature key
-  "my-feature",
+const featureKey = "my-feature";
+const context = {
+  userId: "user-123",
+  country: "nl",
+};
 
-  // attributes
-  {
-    userId: "user-123",
-    country: "nl",
-  }
-);
+const isFeatureEnabled = sdk.getVariation(featureKey, context);
 ```
 
 Learn more about SDK usage here: [https://featurevisor.com/docs/sdks/](https://featurevisor.com/docs/sdks/).

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ const context = {
   country: "nl",
 };
 
-const isFeatureEnabled = sdk.getVariation(featureKey, context);
+const isFeatureEnabled = sdk.getVariation(featureKey, context) === true;
 ```
 
 Learn more about SDK usage here: [https://featurevisor.com/docs/sdks/](https://featurevisor.com/docs/sdks/).

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -25,6 +25,7 @@ These types are supported for attribute values:
 - `string`
 - `integer`
 - `double`
+- `date`
 
 ## Capturing attributes
 

--- a/docs/code-generation.md
+++ b/docs/code-generation.md
@@ -12,7 +12,7 @@ This is an optional step that you may wish to adopt in your workflow. If you do,
 
 - any unintentional spelling mistakes in feature and variable keys
 - worrying about the types of your variables
-- worrying about passing attributes in wrong types
+- worrying about passing attributes in wrong types in context
 
 All of it done being code-driven, thus reducing overall cognitive load of your team.
 
@@ -77,24 +77,24 @@ The imported feature will have several methods available depending how it's defi
 Method for getting its variation is always available:
 
 ```js
-FooFeature.getVariation(attributes = {});
+FooFeature.getVariation(context = {});
 ```
 
 If variables are also defined in the feature, they would be available as:
 
 ```js
-FooFeature.getMyVariableKey(attributes = {});
+FooFeature.getMyVariableKey(context = {});
 ```
 
-## Passing attributes
+## Passing context
 
-You can access the full generated `Attributes` type as follows:
+You can access the full generated `Context` type as follows:
 
 ```js
-import { Attributes } from "@yourorg/features";
+import { Context } from "@yourorg/features";
 ```
 
-Passing `attributes` in all the methods is optional.
+Passing `context` in all the methods is optional.
 
 The generated code is smart enough to know the types of all your individual attributes as defined in your Featurevisor project as YAMLs.
 
@@ -107,8 +107,10 @@ Assuming we have a `foo` feature defined already, which has `boolean` variations
 ```js
 import { FooFeature } from "@yourorg/features";
 
-const attributes = {};
-const fooIsEnabled = FooFeature.getVariation(attributes);
+const context = {
+  userId: "user-123",
+};
+const fooIsEnabled = FooFeature.getVariation(context);
 
 typeof fooIsEnabled === "boolean"; // true
 ```
@@ -128,8 +130,10 @@ If our `foo` feature had a `bar` variable defined, we can evaluate it as follows
 ```js
 import { FooFeature } from "@yourorg/features";
 
-const attributes = {};
-const barValue = FooFeature.getBar(attributes);
+const context = {
+  userId: "user-123",
+};
+const barValue = FooFeature.getBar(context);
 ```
 
 The returned value will honour the variable type as defined in the feature's schema originally.
@@ -141,7 +145,7 @@ interface MyType {
   someKey: string;
 }
 
-const barValue = FooFeature.getBar<MyType>(attributes);
+const barValue = FooFeature.getBar<MyType>(context);
 ```
 
 ## Accessing keys

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -289,12 +289,15 @@ const sdk = createInstance({
 Once the SDK is initialized, you can get variations of your features as follows:
 
 ```js
-const showBanner = sdk.getVariation("showBanner". {
+const featureKey = "showBanner";
+const context = {
   userId: "123",
   country: "de",
-});
+};
+
+const showBanner = sdk.getVariation(featureKey, context);
 ```
 
-Featurevisor SDK will take care of computing the right variation for you against the given `userId` and `country` attributes.
+Featurevisor SDK will take care of computing the right variation for you against the given `userId` and `country` attributes as context.
 
 Find more examples of SDK usage [here](/docs/sdks).

--- a/docs/react.md
+++ b/docs/react.md
@@ -70,9 +70,9 @@ import { useVariation } from "@featurevisor/react";
 
 function MyComponent(props) {
   const featureKey = "myFeatureKey";
-  const attributes = { userId: "123" };
+  const context = { userId: "123" };
 
-  const variation = useVariation(featureKey, attributes);
+  const variation = useVariation(featureKey, context);
 
   if (variation === "b") {
     return <p>B variation</p>;
@@ -98,9 +98,9 @@ import { useVariable } from "@featurevisor/react";
 function MyComponent(props) {
   const featureKey = "myFeatureKey";
   const variableKey = "color";
-  const attributes = { userId: "123" };
+  const context = { userId: "123" };
 
-  const colorValue = useVariable(featureKey, variableKey, attributes);
+  const colorValue = useVariable(featureKey, variableKey, context);
 
   return <p>Color: {colorValue}</p>;
 };

--- a/docs/sdks.md
+++ b/docs/sdks.md
@@ -76,19 +76,31 @@ const sdk = createInstance({
 });
 ```
 
+## Context
+
+Contexts are a set of attribute values that we pass to SDK for evaluating features.
+
+They are objects where keys are the attribute keys, and values are the attribute values.
+
+```js
+const context = {
+  myAttributeKey: "myAttributeValue",
+  anotherAttributeKey: "anotherAttributeValue",
+};
+```
+
 ## Getting variations
 
 Once the SDK is initialized, you can get variations of your features as follows:
 
 ```js
 const featureKey = "my_feature";
-
-const attributes = {
+const context = {
   userId: "123",
   country: "nl",
 };
 
-const variation = sdk.getVariation(featureKey, attributes);
+const variation = sdk.getVariation(featureKey, context);
 ```
 
 ## Getting variables
@@ -96,7 +108,7 @@ const variation = sdk.getVariation(featureKey, attributes);
 ```js
 const variableKey = "bgColor";
 
-const bgColorValue = sdk.getVariable(featureKey, variableKey, attributes);
+const bgColorValue = sdk.getVariable(featureKey, variableKey, context);
 ```
 
 ## Activation
@@ -113,19 +125,19 @@ const sdk = createInstance({
   onActivation: function (
     featureKey,
     variationValue,
-    allAttributes,
-    capturedAttributes
+    fullContext,
+    captureContext
   ) {
-    // allAttributes (object):
+    // fullContext (object):
     //   - all the attributes used for evaluating
 
-    // capturedAttributes (object):
+    // captureContext (object):
     //   - attributes that you want to capture,
     //   - marked as `capture: true` in Attribute YAMLs
   }
 });
 
-const variation = sdk.activate(featureKey, attributes)
+const variation = sdk.activate(featureKey, context);
 ```
 
 From the `onActivation` handler, you can send the activation event to your analytics service.
@@ -137,56 +149,56 @@ Next to generic `getVariation()`, `activate`, and `getVariable()` methods, there
 ### `boolean`
 
 ```js
-sdk.getVariationBoolean(featureKey, attributes);
-sdk.activateBoolean(featureKey, attributes);
-sdk.getVariableBoolean(featureKey, variableKey, attributes);
+sdk.getVariationBoolean(featureKey, context);
+sdk.activateBoolean(featureKey, context);
+sdk.getVariableBoolean(featureKey, variableKey, context);
 ```
 
 ### `string`
 
 ```js
-sdk.getVariationString(featureKey, attributes);
-sdk.activateString(featureKey, attributes);
-sdk.getVariableString(featureKey, variableKey, attributes);
+sdk.getVariationString(featureKey, context);
+sdk.activateString(featureKey, context);
+sdk.getVariableString(featureKey, variableKey, context);
 ```
 
 ### `integer`
 
 ```js
-sdk.getVariationInteger(featureKey, attributes);
-sdk.activateInteger(featureKey, attributes);
-sdk.getVariableInteger(featureKey, variableKey, attributes);
+sdk.getVariationInteger(featureKey, context);
+sdk.activateInteger(featureKey, context);
+sdk.getVariableInteger(featureKey, variableKey, context);
 ```
 
 ### `double`
 
 ```js
-sdk.getVariationDouble(featureKey, attributes);
-sdk.activateDouble(featureKey, attributes);
-sdk.getVariableDouble(featureKey, variableKey, attributes);
+sdk.getVariationDouble(featureKey, context);
+sdk.activateDouble(featureKey, context);
+sdk.getVariableDouble(featureKey, variableKey, context);
 ```
 
 ### `array`
 
 ```js
-sdk.getVariableArray(featureKey, variableKey, attributes);
+sdk.getVariableArray(featureKey, variableKey, context);
 ```
 
 ### `object`
 
 ```ts
-sdk.getVariableObject<T>(featureKey, variableKey, attributes);
+sdk.getVariableObject<T>(featureKey, variableKey, context);
 ```
 
 ### `json`
 
 ```ts
-sdk.getVariableJSON<T>(featureKey, variableKey, attributes);
+sdk.getVariableJSON<T>(featureKey, variableKey, context);
 ```
 
 ## Initial features
 
-You may want to initialize your SDK with a set of features before SDK has sucessfully fetched the datafile (if using `datafileUrl` option).
+You may want to initialize your SDK with a set of features before SDK has successfully fetched the datafile (if using `datafileUrl` option).
 
 This helps in cases when you fail to fetch the datafile, but you still wish your SDK instance to continue serving a set of sensible default values. And as soon as the datafile is fetched successfully, the SDK will start serving values from there.
 
@@ -309,32 +321,32 @@ const sdk = createInstance({
 });
 ```
 
-Further log levels like `info` and `debug` will help you understand how the feature variations and variables are evaluated in the runtime against given attributes.
+Further log levels like `info` and `debug` will help you understand how the feature variations and variables are evaluated in the runtime against given context.
 
-## Intercepting attributes
+## Intercepting context
 
-You can intercept attributes before they are used for evaluation:
+You can intercept context before they are used for evaluation:
 
 ```js
 import { createInstance } from "@featurevisor/sdk";
 
-const defaultAttributes = {
+const defaultContext = {
   country: "nl",
 };
 
 const sdk = createInstance({
   // ...
-  interceptAttributes: function (attributes) {
-    // return updated attributes
+  interceptContext: function (context) {
+    // return updated context
     return {
-      ...defaultAttributes,
-      ...attributes,
+      ...defaultContext,
+      ...context,
     };
   }
 });
 ```
 
-This is useful when you wish to add a default set of attributes for all your evaluations, giving you the convenience of not having to pass them in every time.
+This is useful when you wish to add a default set of attributes as context for all your evaluations, giving you the convenience of not having to pass them in every time.
 
 ## Refreshing datafile
 
@@ -444,13 +456,13 @@ When a feature is activated:
 sdk.on("activation", function (
   featureKey,
   variationValue,
-  allAttributes,
-  capturedAttributes
+  fullContext,
+  captureContext
 ) {
-  // allAttributes (object):
+  // fullContext (object):
   //   - all the attributes used for evaluating
 
-  // capturedAttributes (object):
+  // captureContext (object):
   //   - attributes that you want to capture,
   //   - marked as `capture: true` in Attribute YAMLs
 });
@@ -512,14 +524,14 @@ sdk.removeAllListeners();
 
 ## Evaluation details
 
-Besides logging with debug level enabled, you can also get more details about how the feature variations and variables are evaluated in the runtime against given attributes:
+Besides logging with debug level enabled, you can also get more details about how the feature variations and variables are evaluated in the runtime against given context:
 
 ```js
 // variation
-const evaluation = sdk.evaluateVariation(featureKey, attributes);
+const evaluation = sdk.evaluateVariation(featureKey, context);
 
 // variable
-const evaluation = sdk.evaluateVariable(featureKey, variableKey, attributes);
+const evaluation = sdk.evaluateVariable(featureKey, variableKey, context);
 ```
 
 The returned object will always contain the following properties:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -21,17 +21,17 @@ tests:
         assertions:
 
           # asserting evaluated variation
-          # against bucketed value and attributes
+          # against bucketed value and context
           - description: Testing variation at 40% in NL
             at: 40
-            attributes:
+            context:
               country: nl
             expectedVariation: false
 
           # asserting evaluated variables
           - description: Testing variables at 90% in NL
             at: 90
-            attributes:
+            context:
               country: nl
             expectedVariables:
               someKey: someValue
@@ -65,12 +65,12 @@ tests:
       - key: netherlands # your segment key
         assertions:
           - description: Testing segment in NL
-            attributes:
+            context:
               country: nl
             expected: true
 
           - description: Testing segment in DE
-            attributes:
+            context:
               country: de
             expected: false
 ```

--- a/docs/use-cases/entitlements.md
+++ b/docs/use-cases/entitlements.md
@@ -154,12 +154,14 @@ sdk.setStickyFeatures({
 Get available entitlements for the known user:
 
 ```js
-const attributes = {
+const featureKey = "plan";
+const variableKey = "entitlements";
+const context = {
   userId: userProfile.id,
   country: userProfile.country,
 };
 
-const entitlements = sdk.getVariable("plan", "entitlements", attributes);
+const entitlements = sdk.getVariable(featureKey, variableKey, context);
 ```
 
 The `entitlements` variable will contain an array of all entitlements the user should have against their current plan.
@@ -329,7 +331,7 @@ This will then require you to evaluate each entitlement separately in your appli
 const canCreatePosts = sdk.getVariable(
   "plan",
   "canCreatePosts",
-  attributes
+  context
 );
 
 if (canCreatePosts) {
@@ -339,6 +341,6 @@ if (canCreatePosts) {
 
 ## Conclusion
 
-When your application and its architecture grows big, and you have multipe teams working and shipping in a distributed fashion, it can become hard to manage entitlements in one place.
+When your application and its architecture grows big, and you have multiple teams working and shipping in a distributed fashion, it can become hard to manage entitlements in one place.
 
 Having them declared in one place as a single source of truth can help you manage them better, and also help you avoid any accidental entitlements leaks.

--- a/docs/use-cases/experiments.md
+++ b/docs/use-cases/experiments.md
@@ -179,13 +179,13 @@ Now we can evaluate the `ctaButton` feature wherever we need to render the CTA b
 
 ```js
 const featureKey = "ctaButton";
-const attributes = {
+const context = {
   deviceId: "device-123",
   country: "nl",
   deviceType: "iphone"
 };
 
-const ctaButtonVariation = sdk.getVariation(featureKey, attributes);
+const ctaButtonVariation = sdk.getVariation(featureKey, context);
 
 if (ctaButtonVariation === "treatment") {
   // render the new CTA button
@@ -287,10 +287,10 @@ In your application, you can access the variables of the `hero` feature as follo
 
 ```js
 const featureKey = "hero";
-const attributes = { deviceId: "device-123" };
+const context = { deviceId: "device-123" };
 
-const headline = sdk.getVariable(featureKey, "headline", attributes);
-const ctaButtonText = sdk.getVariable(featureKey, "ctaButtonText", attributes);
+const headline = sdk.getVariable(featureKey, "headline", context);
+const ctaButtonText = sdk.getVariable(featureKey, "ctaButtonText", context);
 ```
 
 Use the values inside your hero element (component) when you render it.
@@ -311,7 +311,7 @@ const sdk = createInstance({
 
   onReady: () => console.log("Datafile has been fetched and SDK is ready"),
 
-  onActivation: (featureKey, variation, attributes, captureAttributes) => {
+  onActivation: (featureKey, variation, context, captureContext) => {
     // send the event to your analytics platform
     // or any other third-party service
   }
@@ -334,9 +334,9 @@ For example, in the case of our CTA button experiment, we can activate the featu
 
 ```js
 const featureKey = "hero";
-const attributes = { deviceId: "device-123" };
+const context = { deviceId: "device-123" };
 
-sdk.activate(featureKey, attributes);
+sdk.activate(featureKey, context);
 ```
 
 ## Mutually exclusive experiments

--- a/docs/use-cases/microfrontends.md
+++ b/docs/use-cases/microfrontends.md
@@ -292,14 +292,14 @@ Evaluate your features:
 
 ```js
 const featureKey = "showMarketingBanner";
-const attributes = {
+const context = {
   deviceId: "...",
 
   // if available
   userId: "...",
 };
 
-const showMarketingBanner = sdk.getVariation(featureKey, attributes);
+const showMarketingBanner = sdk.getVariation(featureKey, context);
 
 if (showMarketingBanner) {
   // render marketing banner

--- a/docs/use-cases/remote-configuration.md
+++ b/docs/use-cases/remote-configuration.md
@@ -146,12 +146,12 @@ Now we can evaluate the variable in our application:
 ```js
 const featureKey = "checkout";
 const variableKey = "paymentMethods";
-const attributes = { userId: "user-123", country: "nl" };
+const context = { userId: "user-123", country: "nl" };
 
 const paymentMethods = sdk.getVariable(
   featureKey,
   variableKey,
-  attributes
+  context
 );
 
 console.log(paymentMethods);
@@ -212,12 +212,12 @@ Now when we evaluate our features, we will get different results for users in th
 
 ```js
 // Users in the Netherlands
-const attributes = { userId: "user-234", country: "nl" };
+const context = { userId: "user-234", country: "nl" };
 
 const paymentMethods = sdk.getVariable(
   featureKey,
   variableKey,
-  attributes
+  context
 );
 
 console.log(paymentMethods);
@@ -231,12 +231,12 @@ While rest of the world will still get the same result as before (that is the de
 
 ```js
 // Users in the US
-const attributes = { userId: "user-123", country: "us" };
+const context = { userId: "user-123", country: "us" };
 
 const paymentMethods = sdk.getVariable(
   featureKey,
   variableKey,
-  attributes
+  context
 );
 
 console.log(paymentMethods);

--- a/docs/use-cases/testing-in-production.md
+++ b/docs/use-cases/testing-in-production.md
@@ -188,13 +188,16 @@ const sdk = createInstance({
 });
 ```
 
-Evaluate with the right attributes:
+Evaluate with the right set of attributes as context:
 
 ```js
-const isWishlistEnabled = sdk.getVariation("wishlist", {
+const featureKey = "wishlist";
+const context = {
   userId: "user-id-1",
   deviceId: "device-id-1",
-});
+};
+
+const isWishlistEnabled = sdk.getVariation(featureKey, context);
 
 if (isWishlistEnabled) {
   // render the wishlist feature

--- a/docs/vue.md
+++ b/docs/vue.md
@@ -70,9 +70,9 @@ Get a feature's evaluated variation:
 import { useVariation } from "@featurevisor/vue";
 
 const featureKey = "myFeatureKey";
-const attributes = { userId: "123" };
+const context = { userId: "123" };
 
-const variation = useVariation(featureKey, attributes);
+const variation = useVariation(featureKey, context);
 </script>
 
 <template>
@@ -98,9 +98,9 @@ import { useVariable } from "@featurevisor/vue";
 
 const featureKey = "myFeatureKey";
 const variableKey = "color";
-const attributes = { userId: "123" };
+const context = { userId: "123" };
 
-const color = useVariable(featureKey, variableKey, attributes);
+const color = useVariable(featureKey, variableKey, context);
 </script>
 
 <template>

--- a/examples/example-1/tests/bar.spec.yml
+++ b/examples/example-1/tests/bar.spec.yml
@@ -5,7 +5,7 @@ tests:
       - key: bar
         assertions:
           - at: 15 # 30 * 0.5
-            attributes:
+            context:
               country: us
             expectedVariation: control
             expectedVariables:
@@ -16,7 +16,7 @@ tests:
                 alignment: center
 
           - at: 20 # 40 * 0.5
-            attributes:
+            context:
               country: us
             expectedVariation: b
             expectedVariables:
@@ -27,7 +27,7 @@ tests:
                 alignment: center for B
 
           - at: 20 # 40 * 0.5
-            attributes:
+            context:
               country: de
             expectedVariation: b
             expectedVariables:

--- a/examples/example-1/tests/baz.spec.yml
+++ b/examples/example-1/tests/baz.spec.yml
@@ -6,18 +6,18 @@ tests:
         assertions:
           - at: 10
             description: "At 10%, the feature should be enabled"
-            attributes:
+            context:
               country: nl
             expectedVariation: true
 
           - at: 70
             description: "At 70%, the feature should be enabled"
-            attributes:
+            context:
               country: nl
             expectedVariation: true
 
           - at: 90
             description: "At 90%, the feature should be disabled"
-            attributes:
+            context:
               country: nl
             expectedVariation: false

--- a/examples/example-1/tests/discount.spec.yml
+++ b/examples/example-1/tests/discount.spec.yml
@@ -6,18 +6,18 @@ tests:
         assertions:
           - at: 10
             description: "At 10%, the feature should be disabled on 1st January 2023"
-            attributes:
+            context:
               date: 2023-01-01T00:00:00Z
             expectedVariation: false
 
           - at: 70
             description: "At 70%, the feature should be disabled on 25th December 2023"
-            attributes:
+            context:
               date: 2023-12-25T00:00:00Z
             expectedVariation: false
 
           - at: 90
             description: "At 90%, the feature should be enabled on 25th November 2023"
-            attributes:
+            context:
               date: 2023-11-25T00:00:00Z
             expectedVariation: true

--- a/examples/example-1/tests/foo.spec.yml
+++ b/examples/example-1/tests/foo.spec.yml
@@ -5,22 +5,22 @@ tests:
       - key: foo
         assertions:
           - at: 40
-            attributes:
+            context:
               country: de
             expectedVariation: false
 
           - at: 60
-            attributes:
+            context:
               country: ch
             expectedVariation: true
 
           - at: 60
-            attributes:
+            context:
               country: us
             expectedVariation: true
 
           - at: 60
-            attributes:
+            context:
               country: us
             expectedVariation: true
             expectedVariables:
@@ -28,7 +28,7 @@ tests:
               baz: baz_here
 
           - at: 80
-            attributes:
+            context:
               country: de
             expectedVariation: true
             expectedVariables:

--- a/examples/example-1/tests/germany.spec.yml
+++ b/examples/example-1/tests/germany.spec.yml
@@ -2,15 +2,15 @@ tests:
   - segments:
       - key: germany
         assertions:
-          - attributes:
+          - context:
               country: de
             expected: true
 
-          - attributes:
+          - context:
               country: de
               someOtherAttribute: someOtherValue
             expected: true
 
-          - attributes:
+          - context:
               country: notDe
             expected: false

--- a/examples/example-1/tests/qux.spec.yml
+++ b/examples/example-1/tests/qux.spec.yml
@@ -5,7 +5,7 @@ tests:
       - key: qux
         assertions:
           - at: 66.5 # (33.33 * 0.5) + 50
-            attributes:
+            context:
               country: nl
             expectedVariation: control
             expectedVariables:
@@ -13,17 +13,17 @@ tests:
                 foo: bar
 
           - at: 66.665 # (33.33 * 0.5) + 50
-            attributes:
+            context:
               country: nl
             expectedVariation: control
 
           - at: 66.67 # (33.34 * 0.5) + 50
-            attributes:
+            context:
               country: nl
             expectedVariation: control
 
           - at: 66.675 # (33.35 * 0.5) + 50
-            attributes:
+            context:
               country: nl
             expectedVariation: b
             expectedVariables:
@@ -31,26 +31,26 @@ tests:
                 foo: bar b
 
           - at: 67 # (42 * 0.5) + 50
-            attributes:
+            context:
               country: nl
             expectedVariation: b
 
           - at: 83 # (66 * 0.5) + 50
-            attributes:
+            context:
               country: nl
             expectedVariation: b
 
           - at: 83.5 # (67 * 0.5) + 50
-            attributes:
+            context:
               country: nl
             expectedVariation: c
 
           - at: 95 # (90 * 0.5) + 50
-            attributes:
+            context:
               country: de
             expectedVariation: b
 
           - at: 55 # (10 * 0.5) + 50
-            attributes:
+            context:
               country: de
             expectedVariation: b

--- a/examples/example-1/tests/sidebar.spec.yml
+++ b/examples/example-1/tests/sidebar.spec.yml
@@ -5,17 +5,17 @@ tests:
       - key: sidebar
         assertions:
           - at: 5
-            attributes:
+            context:
               country: nl
             expectedVariation: false
 
           - at: 90
-            attributes:
+            context:
               country: nl
             expectedVariation: true
 
           - at: 90
-            attributes:
+            context:
               country: nl
             expectedVariation: true
             expectedVariables:
@@ -23,7 +23,7 @@ tests:
               color: red
 
           - at: 90
-            attributes:
+            context:
               country: de
             expectedVariation: true
             expectedVariables:
@@ -32,21 +32,21 @@ tests:
               title: Sidebar Title for production
 
           - at: 90
-            attributes:
+            context:
               country: us
             expectedVariation: true
             expectedVariables:
               sections: ["home", "about", "contact"]
 
           - at: 90
-            attributes:
+            context:
               country: de
             expectedVariation: true
             expectedVariables:
               sections: ["home", "about", "contact", "imprint"]
 
           - at: 70
-            attributes:
+            context:
               country: nl
               userId: "123"
             expectedVariation: true

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -12,7 +12,7 @@ export const OUTPUT_DIRECTORY_NAME = "dist";
 export const SITE_EXPORT_DIRECTORY_NAME = "out";
 
 export const CONFIG_MODULE_NAME = "featurevisor.config.js";
-export const ROOT_DIR_PLACECOLDER = "<rootDir>";
+export const ROOT_DIR_PLACEHOLDER = "<rootDir>";
 
 export const DEFAULT_ENVIRONMENTS = ["staging", "production"];
 export const DEFAULT_TAGS = ["all"];
@@ -69,8 +69,8 @@ export function getProjectConfig(rootDirectoryPath: string): ProjectConfig {
   Object.keys(baseConfig).forEach((key) => {
     finalConfig[key] = customConfig[key] || baseConfig[key];
 
-    if (key.endsWith("Path") && finalConfig[key].indexOf(ROOT_DIR_PLACECOLDER) !== -1) {
-      finalConfig[key] = finalConfig[key].replace(ROOT_DIR_PLACECOLDER, rootDirectoryPath);
+    if (key.endsWith("Path") && finalConfig[key].indexOf(ROOT_DIR_PLACEHOLDER) !== -1) {
+      finalConfig[key] = finalConfig[key].replace(ROOT_DIR_PLACEHOLDER, rootDirectoryPath);
     }
   });
 

--- a/packages/core/src/generate-code/typescript.ts
+++ b/packages/core/src/generate-code/typescript.ts
@@ -112,23 +112,24 @@ export function generateTypeScriptCodeForProject(
       return !attribute.archived;
     });
 
+  // context
   const attributeProperties = attributes
     .map((attribute) => {
       return `  ${attribute.key}?: ${attribute.typescriptType};`;
     })
     .join("\n");
-  const attributesContent = `
+  const contextContent = `
 import { AttributeKey, AttributeValue } from "@featurevisor/types";
 
-export interface Attributes {
+export interface Context {
 ${attributeProperties}
   [key: AttributeKey]: AttributeValue;
 }
 `.trimStart();
 
-  const attributesTypeFilePath = path.join(outputPath, "Attributes.ts");
-  fs.writeFileSync(attributesTypeFilePath, attributesContent);
-  console.log(`Attributes type file written at: ${attributesTypeFilePath}`);
+  const contextTypeFilePath = path.join(outputPath, "Context.ts");
+  fs.writeFileSync(contextTypeFilePath, contextContent);
+  console.log(`Context type file written at: ${contextTypeFilePath}`);
 
   // features
   const featureNamespaces: string[] = [];
@@ -161,28 +162,28 @@ ${attributeProperties}
         if (variableType === "json" || variableType === "object") {
           variableMethods += `
 
-  export function get${getPascalCase(variableKey)}<T>(attributes: Attributes = {}) {
-    return getInstance().${internalMethodName}<T>(key, "${variableKey}", attributes);
+  export function get${getPascalCase(variableKey)}<T>(context: Context = {}) {
+    return getInstance().${internalMethodName}<T>(key, "${variableKey}", context);
   }`;
         } else {
           variableMethods += `
 
-  export function get${getPascalCase(variableKey)}(attributes: Attributes = {}) {
-    return getInstance().${internalMethodName}(key, "${variableKey}", attributes);
+  export function get${getPascalCase(variableKey)}(context: Context = {}) {
+    return getInstance().${internalMethodName}(key, "${variableKey}", context);
   }`;
         }
       }
     }
 
     const featureContent = `
-import { Attributes } from "./Attributes";
+import { Context } from "./Context";
 import { getInstance } from "./instance";
 
 export namespace ${namespaceValue} {
   export const key = "${featureKey}";
 
-  export function getVariation(attributes: Attributes = {}) {
-    return getInstance().getVariation${getPascalCase(variationType)}(key, attributes);
+  export function getVariation(context: Context = {}) {
+    return getInstance().getVariation${getPascalCase(variationType)}(key, context);
   }${variableMethods}
 }
 `.trimStart();
@@ -194,7 +195,7 @@ export namespace ${namespaceValue} {
 
   // index
   const indexContent =
-    [`export * from "./Attributes";`, `export * from "./instance";`]
+    [`export * from "./Context";`, `export * from "./instance";`]
       .concat(
         featureNamespaces.map((featureNamespace) => {
           return `export * from "./${featureNamespace}";`;

--- a/packages/core/src/linter.ts
+++ b/packages/core/src/linter.ts
@@ -380,7 +380,7 @@ export function getTestsJoiSchema(
                 Joi.object({
                   description: Joi.string().optional(),
                   at: Joi.number().precision(3).min(0).max(100),
-                  attributes: Joi.object(),
+                  context: Joi.object(),
 
                   // @TODO: one or both below
                   expectedVariation: Joi.alternatives().try(
@@ -402,7 +402,7 @@ export function getTestsJoiSchema(
             assertions: Joi.array().items(
               Joi.object({
                 description: Joi.string().optional(),
-                attributes: Joi.object(),
+                context: Joi.object(),
                 expected: Joi.boolean(),
               }),
             ),

--- a/packages/core/src/tester.ts
+++ b/packages/core/src/tester.ts
@@ -108,7 +108,7 @@ export function testProject(rootDirectoryPath: string, projectConfig: ProjectCon
             let assertionHasError = false;
 
             const expected = assertion.expected;
-            const actual = allConditionsAreMatched(conditions, assertion.attributes);
+            const actual = allConditionsAreMatched(conditions, assertion.context);
 
             if (actual !== expected) {
               hasError = true;
@@ -160,7 +160,7 @@ export function testProject(rootDirectoryPath: string, projectConfig: ProjectCon
 
             // variation
             if ("expectedVariation" in assertion) {
-              const variation = sdk.getVariation(featureKey, assertion.attributes);
+              const variation = sdk.getVariation(featureKey, assertion.context);
 
               if (variation !== assertion.expectedVariation) {
                 hasError = true;
@@ -177,7 +177,7 @@ export function testProject(rootDirectoryPath: string, projectConfig: ProjectCon
               Object.keys(assertion.expectedVariables).forEach(function (variableKey) {
                 const expectedValue =
                   assertion.expectedVariables && assertion.expectedVariables[variableKey];
-                const actualValue = sdk.getVariable(featureKey, variableKey, assertion.attributes);
+                const actualValue = sdk.getVariable(featureKey, variableKey, assertion.context);
 
                 let passed;
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -45,7 +45,7 @@ function Root() {
 
 ### `activateFeature`
 
-> activateFeature(featureName, attributes = {}): VariationValue | undefined
+> activateFeature(featureKey, context = {}): VariationValue | undefined
 
 Hook for activate feature.
 
@@ -78,13 +78,13 @@ function App() {
 
 ### `useVariation`
 
-> useVariation(featureKey, attributes = {}): VariationValue | undefined
+> useVariation(featureKey, context = {}): VariationValue | undefined
 
 Hook for getting variation value.
 
 ### `useVariable`
 
-> useVariable(featureKey, variableKey, attributes = {}): VariableValue | undefined
+> useVariable(featureKey, variableKey, context = {}): VariableValue | undefined
 
 Hook for getting variable value.
 

--- a/packages/react/src/activateFeature.ts
+++ b/packages/react/src/activateFeature.ts
@@ -1,12 +1,12 @@
-import { Attributes, FeatureKey, VariationValue } from "@featurevisor/types";
+import { Context, FeatureKey, VariationValue } from "@featurevisor/types";
 
 import { useSdk } from "./useSdk";
 
 export function activateFeature(
   featureKey: FeatureKey,
-  attributes: Attributes = {},
+  context: Context = {},
 ): VariationValue | undefined {
   const sdk = useSdk();
 
-  return sdk.activate(featureKey, attributes);
+  return sdk.activate(featureKey, context);
 }

--- a/packages/react/src/useVariable.ts
+++ b/packages/react/src/useVariable.ts
@@ -1,13 +1,13 @@
-import { Attributes, FeatureKey, VariableKey, VariableValue } from "@featurevisor/types";
+import { Context, FeatureKey, VariableKey, VariableValue } from "@featurevisor/types";
 
 import { useSdk } from "./useSdk";
 
 export function useVariable(
   featureKey: FeatureKey,
   variableKey: VariableKey,
-  attributes: Attributes = {},
+  context: Context = {},
 ): VariableValue | undefined {
   const sdk = useSdk();
 
-  return sdk.getVariable(featureKey, variableKey, attributes);
+  return sdk.getVariable(featureKey, variableKey, context);
 }

--- a/packages/react/src/useVariation.ts
+++ b/packages/react/src/useVariation.ts
@@ -1,12 +1,12 @@
-import { Attributes, FeatureKey, VariationValue } from "@featurevisor/types";
+import { Context, FeatureKey, VariationValue } from "@featurevisor/types";
 
 import { useSdk } from "./useSdk";
 
 export function useVariation(
   featureKey: FeatureKey,
-  attributes: Attributes = {},
+  context: Context = {},
 ): VariationValue | undefined {
   const sdk = useSdk();
 
-  return sdk.getVariation(featureKey, attributes);
+  return sdk.getVariation(featureKey, context);
 }

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -14,7 +14,7 @@ Visit [https://featurevisor.com/docs/sdks/](https://featurevisor.com/docs/sdks/)
   - [`datafileUrl`](#datafileurl)
   - [`handleDatafileFetch`](#handledatafilefetch)
   - [`initialFeatures`](#initialfeatures)
-  - [`interceptAttributes`](#interceptattributes)
+  - [`interceptContext`](#interceptcontext)
   - [`logger`](#logger)
   - [`onActivation`](#onactivation)
   - [`onReady`](#onready)
@@ -70,7 +70,7 @@ Use it to take over bucketing key generation process.
 
 ```js
 const sdk = createInstance({
-  configureBucketKey: (feature, attributes, bucketKey) => {
+  configureBucketKey: (feature, context, bucketKey) => {
     return bucketKey;
   }
 });
@@ -85,7 +85,7 @@ Use it to take over bucketing process.
 
 ```js
 const sdk = createInstance({
-  configureBucketValue: (feature, attributes, bucketValue) => {
+  configureBucketValue: (feature, context, bucketValue) => {
     return bucketValue; // 0 to 100,000
   }
 });
@@ -143,15 +143,15 @@ const sdk = createInstance({
 });
 ```
 
-### `interceptAttributes`
+### `interceptContext`
 
 - Type: `function`
 - Required: no
 
-Intercept given attributes before they are used to bucket the user:
+Intercept given context before they are used to bucket the user:
 
 ```js
-const defaultAttributes = {
+const defaultContext = {
   platform: "web",
   locale: "en-US",
   country: "US",
@@ -160,10 +160,10 @@ const defaultAttributes = {
 };
 
 const sdk = createInstance({
-  interceptAttributes: (attributes) => {
+  interceptContext: (context) => {
     return {
-      ...defaultAttributes,
-      ...attributes,
+      ...defaultContext,
+      ...context,
     };
   }
 });
@@ -198,13 +198,13 @@ Capture activated features along with their evaluated variation:
 
 ```js
 const sdk = createInstance({
-  onActivation: (featureKey, variation, attributes, captureAttributes) => {
+  onActivation: (featureKey, variation, context, captureContext) => {
     // do something with the activated feature
   }
 });
 ```
 
-`captureAttributes` will only contain attributes that are marked as `capture: true` in the Attributes' YAML files.
+`captureContext` will only contain attributes that are marked as `capture: true` in the Attributes' YAML files.
 
 ### `onReady`
 
@@ -296,7 +296,7 @@ These methods are available once the SDK instance is created:
 
 ### `getVariation`
 
-> `getVariation(featureKey: string, attributes: Attributes): VariationValue`
+> `getVariation(featureKey: string, context: Context): VariationValue`
 
 Also supports additional type specific methods:
 
@@ -307,7 +307,7 @@ Also supports additional type specific methods:
 
 ### `getVariable`
 
-> `getVariable(featureKey: string, variableKey: string, attributes: Attributes): VariableValue`
+> `getVariable(featureKey: string, variableKey: string, context: Context): VariableValue`
 
 Also supports additional type specific methods:
 
@@ -321,7 +321,7 @@ Also supports additional type specific methods:
 
 ### `activate`
 
-> `activate(featureKey: string, attributes: Attributes): VariationValue`
+> `activate(featureKey: string, context: Context): VariationValue`
 
 Same as `getVariation`, but also calls the `onActivation` callback.
 

--- a/packages/sdk/src/conditions.ts
+++ b/packages/sdk/src/conditions.ts
@@ -1,71 +1,71 @@
 import { compareVersions } from "compare-versions";
 
-import { Attributes, Condition, PlainCondition } from "@featurevisor/types";
+import { Context, Condition, PlainCondition } from "@featurevisor/types";
 
-export function conditionIsMatched(condition: PlainCondition, attributes: Attributes): boolean {
+export function conditionIsMatched(condition: PlainCondition, context: Context): boolean {
   const { attribute, operator, value } = condition;
 
   if (operator === "equals") {
-    return attributes[attribute] === value;
+    return context[attribute] === value;
   } else if (operator === "notEquals") {
-    return attributes[attribute] !== value;
+    return context[attribute] !== value;
   } else if (operator === "before" || operator === "after") {
     // date comparisons
-    const valueInAttributes = attributes[attribute] as string | Date;
+    const valueInContext = context[attribute] as string | Date;
 
-    const dateInAttributes =
-      valueInAttributes instanceof Date ? valueInAttributes : new Date(valueInAttributes);
+    const dateInContext =
+      valueInContext instanceof Date ? valueInContext : new Date(valueInContext);
     const dateInCondition = value instanceof Date ? value : new Date(value as string);
 
     return operator === "before"
-      ? dateInAttributes < dateInCondition
-      : dateInAttributes > dateInCondition;
-  } else if (typeof attributes[attribute] === "string" && Array.isArray(value)) {
+      ? dateInContext < dateInCondition
+      : dateInContext > dateInCondition;
+  } else if (typeof context[attribute] === "string" && Array.isArray(value)) {
     // array
-    const valueInAttributes = attributes[attribute] as string;
+    const valueInContext = context[attribute] as string;
 
     if (operator === "in") {
-      return value.indexOf(valueInAttributes) !== -1;
+      return value.indexOf(valueInContext) !== -1;
     } else if (operator === "notIn") {
-      return value.indexOf(valueInAttributes) === -1;
+      return value.indexOf(valueInContext) === -1;
     }
-  } else if (typeof attributes[attribute] === "string" && typeof value === "string") {
+  } else if (typeof context[attribute] === "string" && typeof value === "string") {
     // string
-    const valueInAttributes = attributes[attribute] as string;
+    const valueInContext = context[attribute] as string;
 
     if (operator === "contains") {
-      return valueInAttributes.indexOf(value) !== -1;
+      return valueInContext.indexOf(value) !== -1;
     } else if (operator === "notContains") {
-      return valueInAttributes.indexOf(value) === -1;
+      return valueInContext.indexOf(value) === -1;
     } else if (operator === "startsWith") {
-      return valueInAttributes.startsWith(value);
+      return valueInContext.startsWith(value);
     } else if (operator === "endsWith") {
-      return valueInAttributes.endsWith(value);
+      return valueInContext.endsWith(value);
     } else if (operator === "semverEquals") {
-      return compareVersions(valueInAttributes, value) === 0;
+      return compareVersions(valueInContext, value) === 0;
     } else if (operator === "semverNotEquals") {
-      return compareVersions(valueInAttributes, value) !== 0;
+      return compareVersions(valueInContext, value) !== 0;
     } else if (operator === "semverGreaterThan") {
-      return compareVersions(valueInAttributes, value) === 1;
+      return compareVersions(valueInContext, value) === 1;
     } else if (operator === "semverGreaterThanOrEquals") {
-      return compareVersions(valueInAttributes, value) >= 0;
+      return compareVersions(valueInContext, value) >= 0;
     } else if (operator === "semverLessThan") {
-      return compareVersions(valueInAttributes, value) === -1;
+      return compareVersions(valueInContext, value) === -1;
     } else if (operator === "semverLessThanOrEquals") {
-      return compareVersions(valueInAttributes, value) <= 0;
+      return compareVersions(valueInContext, value) <= 0;
     }
-  } else if (typeof attributes[attribute] === "number" && typeof value === "number") {
+  } else if (typeof context[attribute] === "number" && typeof value === "number") {
     // numeric
-    const valueInAttributes = attributes[attribute] as number;
+    const valueInContext = context[attribute] as number;
 
     if (operator === "greaterThan") {
-      return valueInAttributes > value;
+      return valueInContext > value;
     } else if (operator === "greaterThanOrEquals") {
-      return valueInAttributes >= value;
+      return valueInContext >= value;
     } else if (operator === "lessThan") {
-      return valueInAttributes < value;
+      return valueInContext < value;
     } else if (operator === "lessThanOrEquals") {
-      return valueInAttributes <= value;
+      return valueInContext <= value;
     }
   }
 
@@ -74,18 +74,18 @@ export function conditionIsMatched(condition: PlainCondition, attributes: Attrib
 
 export function allConditionsAreMatched(
   conditions: Condition[] | Condition,
-  attributes: Attributes,
+  context: Context,
 ): boolean {
   if ("attribute" in conditions) {
-    return conditionIsMatched(conditions, attributes);
+    return conditionIsMatched(conditions, context);
   }
 
   if ("and" in conditions && Array.isArray(conditions.and)) {
-    return conditions.and.every((c) => allConditionsAreMatched(c, attributes));
+    return conditions.and.every((c) => allConditionsAreMatched(c, context));
   }
 
   if ("or" in conditions && Array.isArray(conditions.or)) {
-    return conditions.or.some((c) => allConditionsAreMatched(c, attributes));
+    return conditions.or.some((c) => allConditionsAreMatched(c, context));
   }
 
   if ("not" in conditions && Array.isArray(conditions.not)) {
@@ -95,13 +95,13 @@ export function allConditionsAreMatched(
           {
             and: conditions.not,
           },
-          attributes,
+          context,
         ) === false,
     );
   }
 
   if (Array.isArray(conditions)) {
-    return conditions.every((c) => allConditionsAreMatched(c, attributes));
+    return conditions.every((c) => allConditionsAreMatched(c, context));
   }
 
   return false;

--- a/packages/sdk/src/feature.ts
+++ b/packages/sdk/src/feature.ts
@@ -1,4 +1,4 @@
-import { Allocation, Attributes, Traffic, Feature, Force } from "@featurevisor/types";
+import { Allocation, Context, Traffic, Feature, Force } from "@featurevisor/types";
 import { DatafileReader } from "./datafileReader";
 import { allGroupSegmentsAreMatched } from "./segments";
 import { allConditionsAreMatched } from "./conditions";
@@ -26,7 +26,7 @@ export interface MatchedTrafficAndAllocation {
 
 export function getMatchedTrafficAndAllocation(
   traffic: Traffic[],
-  attributes: Attributes,
+  context: Context,
   bucketValue: number,
   datafileReader: DatafileReader,
   logger: Logger,
@@ -37,7 +37,7 @@ export function getMatchedTrafficAndAllocation(
     if (
       !allGroupSegmentsAreMatched(
         typeof t.segments === "string" && t.segments !== "*" ? JSON.parse(t.segments) : t.segments,
-        attributes,
+        context,
         datafileReader,
       )
     ) {
@@ -61,7 +61,7 @@ export function getMatchedTrafficAndAllocation(
 
 export function findForceFromFeature(
   feature: Feature,
-  attributes: Attributes,
+  context: Context,
   datafileReader: DatafileReader,
 ): Force | undefined {
   if (!feature.force) {
@@ -70,11 +70,11 @@ export function findForceFromFeature(
 
   return feature.force.find((f: Force) => {
     if (f.conditions) {
-      return allConditionsAreMatched(f.conditions, attributes);
+      return allConditionsAreMatched(f.conditions, context);
     }
 
     if (f.segments) {
-      return allGroupSegmentsAreMatched(f.segments, attributes, datafileReader);
+      return allGroupSegmentsAreMatched(f.segments, context, datafileReader);
     }
 
     return false;

--- a/packages/sdk/src/instance.spec.ts
+++ b/packages/sdk/src/instance.spec.ts
@@ -73,7 +73,7 @@ describe("sdk: instance", function () {
         attributes: [],
         segments: [],
       },
-      configureBucketKey: function (feature, attributes, bucketKey) {
+      configureBucketKey: function (feature, context, bucketKey) {
         capturedBucketKey = bucketKey;
 
         return bucketKey;
@@ -117,7 +117,7 @@ describe("sdk: instance", function () {
         attributes: [],
         segments: [],
       },
-      configureBucketKey: function (feature, attributes, bucketKey) {
+      configureBucketKey: function (feature, context, bucketKey) {
         capturedBucketKey = bucketKey;
 
         return bucketKey;
@@ -162,7 +162,7 @@ describe("sdk: instance", function () {
         attributes: [],
         segments: [],
       },
-      configureBucketKey: function (feature, attributes, bucketKey) {
+      configureBucketKey: function (feature, context, bucketKey) {
         capturedBucketKey = bucketKey;
 
         return bucketKey;
@@ -185,7 +185,7 @@ describe("sdk: instance", function () {
     expect(capturedBucketKey).toEqual("456.test");
   });
 
-  it("should intercept attributes", function () {
+  it("should intercept context", function () {
     let intercepted = false;
 
     const sdk = createInstance({
@@ -214,11 +214,11 @@ describe("sdk: instance", function () {
         attributes: [],
         segments: [],
       },
-      interceptAttributes: function (attributes) {
+      interceptContext: function (context) {
         intercepted = true;
 
         return {
-          ...attributes,
+          ...context,
         };
       },
     });

--- a/packages/sdk/src/segments.ts
+++ b/packages/sdk/src/segments.ts
@@ -1,14 +1,14 @@
-import { Attributes, GroupSegment, Segment, Condition } from "@featurevisor/types";
+import { Context, GroupSegment, Segment, Condition } from "@featurevisor/types";
 import { allConditionsAreMatched } from "./conditions";
 import { DatafileReader } from "./datafileReader";
 
-export function segmentIsMatched(segment: Segment, attributes: Attributes): boolean {
-  return allConditionsAreMatched(segment.conditions as Condition | Condition[], attributes);
+export function segmentIsMatched(segment: Segment, context: Context): boolean {
+  return allConditionsAreMatched(segment.conditions as Condition | Condition[], context);
 }
 
 export function allGroupSegmentsAreMatched(
   groupSegments: GroupSegment | GroupSegment[] | "*",
-  attributes: Attributes,
+  context: Context,
   datafileReader: DatafileReader,
 ): boolean {
   if (groupSegments === "*") {
@@ -19,7 +19,7 @@ export function allGroupSegmentsAreMatched(
     const segment = datafileReader.getSegment(groupSegments);
 
     if (segment) {
-      return segmentIsMatched(segment, attributes);
+      return segmentIsMatched(segment, context);
     }
 
     return false;
@@ -28,27 +28,27 @@ export function allGroupSegmentsAreMatched(
   if (typeof groupSegments === "object") {
     if ("and" in groupSegments && Array.isArray(groupSegments.and)) {
       return groupSegments.and.every((groupSegment) =>
-        allGroupSegmentsAreMatched(groupSegment, attributes, datafileReader),
+        allGroupSegmentsAreMatched(groupSegment, context, datafileReader),
       );
     }
 
     if ("or" in groupSegments && Array.isArray(groupSegments.or)) {
       return groupSegments.or.some((groupSegment) =>
-        allGroupSegmentsAreMatched(groupSegment, attributes, datafileReader),
+        allGroupSegmentsAreMatched(groupSegment, context, datafileReader),
       );
     }
 
     if ("not" in groupSegments && Array.isArray(groupSegments.not)) {
       return groupSegments.not.every(
         (groupSegment) =>
-          allGroupSegmentsAreMatched(groupSegment, attributes, datafileReader) === false,
+          allGroupSegmentsAreMatched(groupSegment, context, datafileReader) === false,
       );
     }
   }
 
   if (Array.isArray(groupSegments)) {
     return groupSegments.every((groupSegment) =>
-      allGroupSegmentsAreMatched(groupSegment, attributes, datafileReader),
+      allGroupSegmentsAreMatched(groupSegment, context, datafileReader),
     );
   }
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -2,7 +2,7 @@ export type AttributeKey = string;
 
 export type AttributeValue = string | number | boolean | Date | null | undefined;
 
-export interface Attributes {
+export interface Context {
   [key: AttributeKey]: AttributeValue;
 }
 
@@ -331,7 +331,7 @@ export interface ExistingState {
 export interface FeatureAssertion {
   description?: string;
   at: Weight; // bucket weight: 0 to 100
-  attributes: Attributes;
+  context: Context;
   expectedVariation?: VariationValue;
   expectedVariables?: {
     [key: VariableKey]: VariableValue;
@@ -345,7 +345,7 @@ export interface TestFeature {
 
 export interface SegmentAssertion {
   description?: string;
-  attributes: Attributes;
+  context: Context;
   expected: boolean;
 }
 

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -43,7 +43,7 @@ setupApp(app, sdk);
 
 ### `activateFeature`
 
-> activateFeature(featureName, attributes = {}): VariationValue | undefined
+> activateFeature(featureKey, context = {}): VariationValue | undefined
 
 Function for activating feature.
 
@@ -61,13 +61,13 @@ Function for checking if Featurevisor SDK is ready.
 
 ### `useVariation`
 
-> useVariation(featureKey, attributes = {}): VariationValue | undefined
+> useVariation(featureKey, context = {}): VariationValue | undefined
 
 Function for getting variation value.
 
 ### `useVariable`
 
-> useVariable(featureKey, variableKey, attributes = {}): VariableValue | undefined
+> useVariable(featureKey, variableKey, context = {}): VariableValue | undefined
 
 Function for getting variable value.
 

--- a/packages/vue/src/activateFeature.ts
+++ b/packages/vue/src/activateFeature.ts
@@ -1,12 +1,12 @@
-import { Attributes, FeatureKey, VariationValue } from "@featurevisor/types";
+import { Context, FeatureKey, VariationValue } from "@featurevisor/types";
 
 import { useSdk } from "./useSdk";
 
 export function activateFeature(
   featureKey: FeatureKey,
-  attributes: Attributes = {},
+  context: Context = {},
 ): VariationValue | undefined {
   const sdk = useSdk();
 
-  return sdk.activate(featureKey, attributes);
+  return sdk.activate(featureKey, context);
 }

--- a/packages/vue/src/useVariable.ts
+++ b/packages/vue/src/useVariable.ts
@@ -1,13 +1,13 @@
-import { Attributes, FeatureKey, VariableKey, VariableValue } from "@featurevisor/types";
+import { Context, FeatureKey, VariableKey, VariableValue } from "@featurevisor/types";
 
 import { useSdk } from "./useSdk";
 
 export function useVariable(
   featureKey: FeatureKey,
   variableKey: VariableKey,
-  attributes: Attributes = {},
+  context: Context = {},
 ): VariableValue | undefined {
   const sdk = useSdk();
 
-  return sdk.getVariable(featureKey, variableKey, attributes);
+  return sdk.getVariable(featureKey, variableKey, context);
 }

--- a/packages/vue/src/useVariation.ts
+++ b/packages/vue/src/useVariation.ts
@@ -1,12 +1,12 @@
-import { Attributes, FeatureKey, VariationValue } from "@featurevisor/types";
+import { Context, FeatureKey, VariationValue } from "@featurevisor/types";
 
 import { useSdk } from "./useSdk";
 
 export function useVariation(
   featureKey: FeatureKey,
-  attributes: Attributes = {},
+  context: Context = {},
 ): VariationValue | undefined {
   const sdk = useSdk();
 
-  return sdk.getVariation(featureKey, attributes);
+  return sdk.getVariation(featureKey, context);
 }


### PR DESCRIPTION
## What's done

- `attributes` in the SDK API has been changed to `context`

## Migration path

- `interceptAttributes` option in SDK has been changed to `interceptContext`
- in test specs, the `attributes` key in assertions changed to `context`

Other than those, it's only an argument name change for all.