### PR TITLE
fix: "npm ci" → "npm install" message on project setup

### DIFF
--- a/packages/core/src/init.ts
+++ b/packages/core/src/init.ts
@@ -35,7 +35,7 @@ export function initProject(
         .on("finish", () => {
           console.log(`Project scaffolded in ${directoryPath}`);
           console.log(``);
-          console.log(`Please run "npm ci" in the directory above.`);
+          console.log(`Please run "npm install" in the directory above.`);
 
           resolve(true);
         });


### PR DESCRIPTION
Following the instructions on https://featurevisor.com/docs/quick-start/, at some point the CLI let me run `npm ci` on a project that doesn't have the `package-lock.json` file just yet (documentation says to run `npm install` actually`).

<img width="703" alt="Screenshot 2023-07-15 at 15 20 24" src="https://github.com/fahad19/featurevisor/assets/3715587/cb494588-d79b-4288-99bc-ed2e842f1334">