### PR TITLE
feat: SDK to support isEnabled() checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,9 @@ const context = {
   country: "nl",
 };
 
-const isFeatureEnabled = sdk.getVariation(featureKey, context) === true;
+const isFeatureEnabled = sdk.isEnabled(featureKey, context);
+const variation = sdk.getVariation(featureKey, context);
+const someVariable = sdk.getVariable(featureKey, "someVariableKey", context);
 ```
 
 Learn more about SDK usage here: [https://featurevisor.com/docs/sdks/](https://featurevisor.com/docs/sdks/).

--- a/docs/code-generation.md
+++ b/docs/code-generation.md
@@ -100,27 +100,26 @@ The generated code is smart enough to know the types of all your individual attr
 
 Therefore, if you pass an attribute in wrong type for evaluating variation or variables, you will get a TypeScript error.
 
-## Getting variation
+## Checking if enabled
 
-Assuming we have a `foo` feature defined already, which has `boolean` variations:
+Assuming we have a `foo` feature defined already in `features/foo.yml` file:
 
 ```js
 import { FooFeature } from "@yourorg/features";
 
-const context = {
-  userId: "user-123",
-};
-const fooIsEnabled = FooFeature.getVariation(context);
-
-typeof fooIsEnabled === "boolean"; // true
+const context = { userId: "user-123" };
+const isFooEnabled = FooFeature.isEnabled(context);
 ```
 
-If our defined feature had `string` variations instead, the returned type would of course be `string`:
+## Getting variation
+
+We can use the same imported feature to get its variation:
 
 ```js
-const fooVariation = FooFeature.getVariation();
+import { FooFeature } from "@yourorg/features";
 
-typeof fooVariation === "string"; // true
+const context = { userId: "user-123" };
+const fooVariation = FooFeature.getVariation(context);
 ```
 
 ## Evaluating variable
@@ -130,9 +129,7 @@ If our `foo` feature had a `bar` variable defined, we can evaluate it as follows
 ```js
 import { FooFeature } from "@yourorg/features";
 
-const context = {
-  userId: "user-123",
-};
+const context = { userId: "user-123" };
 const barValue = FooFeature.getBar(context);
 ```
 

--- a/docs/code-generation.md
+++ b/docs/code-generation.md
@@ -74,7 +74,13 @@ import { FooFeature } from "@yourorg/features";
 
 The imported feature will have several methods available depending how it's defined.
 
-Method for getting its variation is always available:
+Method for checking if the feature is enabled or not is always available:
+
+```js
+FooFeature.isEnabled(context = {});
+```
+
+If your feature has any defined variations, then `getVariation` method would also be available:
 
 ```js
 FooFeature.getVariation(context = {});

--- a/docs/features.md
+++ b/docs/features.md
@@ -20,12 +20,6 @@ tags:
 bucketBy: userId
 
 environments:
-  staging:
-    rules:
-      - key: "1"
-        segments: "*"
-        percentage: 100
-
   production:
     rules:
       - key: "1"
@@ -33,7 +27,9 @@ environments:
         percentage: 100
 ```
 
-Quite a lot of things are happening there. We will go through each of the properties from the snippet above in the following sections.
+This is the smallest possible definition of a feature.
+
+Quite a few are happening there. We will go through each of the properties from the snippet above and more in the following sections.
 
 ## Description
 
@@ -94,19 +90,17 @@ bucketBy:
 
 ## Variations
 
-A feature can have multiple variations. Each variation must have a different string value.
-
-This is useful for running A/B test experiments.
+A feature can have multiple variations if you wish to run A/B tests. Each variation must have a different string value.
 
 ```yml
 variations:
   - value: control
     weight: 50
 
-  - value: b
+  - value: firstTreatment
     weight: 25
 
-  - value: c
+  - value: secondTreatment
     weight: 25
 ```
 
@@ -570,7 +564,7 @@ environments:
         enabled: true
 
         # forced variation
-        variation: true
+        variation: treatment
 
         # variables can also be forced
         variables:

--- a/docs/features.md
+++ b/docs/features.md
@@ -19,15 +19,6 @@ tags:
 
 bucketBy: userId
 
-defaultVariation: false
-
-variations:
-  - value: true
-    weight: 100
-
-  - value: false
-    weight: 0
-
 environments:
   staging:
     rules:
@@ -101,40 +92,13 @@ bucketBy:
     - deviceId
 ```
 
-## Default variation
-
-If no rollout rules are matched for the user, Featurevisor SDKs will fall back to the default variation as set in `defaultVariation`.
-
-```yml
-# ...
-defaultVariation: false
-```
-
 ## Variations
 
-A feature can have multiple variations. Each variation must have a different value, but all variations must be of the same type.
+A feature can have multiple variations. Each variation must have a different string value.
 
-### Boolean flags
-
-Here, we have used simple boolean values for the variations:
+This is useful for running A/B test experiments.
 
 ```yml
-# ...
-variations:
-  - value: true
-    weight: 100
-
-  - value: false
-    weight: 0
-```
-
-### A/B tests
-
-But we could have also used `string` type variations where number of total variations can be more than two:
-
-```yml
-defaultVariation: control
-
 variations:
   - value: control
     weight: 50
@@ -151,7 +115,9 @@ The sum of all variations' weights must be 100.
 You can have upto 2 decimal places for each weight.
 
 {% callout type="note" title="Control variation" %}
-In the world of experimentation, the default variation is usually called the `control` variation.
+In the world of experimentation, the default variation is usually called the `control` variation, and the second variation is called `treatment`.
+
+But you are free to name them however you want, and create as many variations as you want.
 {% /callout %}
 
 ## Environments
@@ -361,22 +327,22 @@ variablesSchema:
     defaultValue: red
 ```
 
-Then, we can assign values to the variables inside variations:
+We can assign values to the variables inside variations:
 
 ```yml
 # ...
 variations:
-  - value: true
-    weight: 100
+  - value: control
+    weight: 50
+
+  - value: treatment
+    weight: 50
     variables:
       - key: bgColor
         value: blue
-
-  - value: false
-    weight: 0
 ```
 
-If users are bucketed in the `true` variation, they will get the `bgColor` variable value of `blue`. Otherwise they will fall back to the default value of `red` as defined in the schema.
+If users are bucketed in the `treatment` variation, they will get the `bgColor` variable value of `blue`. Otherwise they will fall back to the default value of `red` as defined in the variables schema.
 
 ### Supported types
 
@@ -413,7 +379,7 @@ Or, you can override within variations:
 # ...
 variations:
   # ...
-  - value: true
+  - value: treatment
     weight: 100
     variables:
       - key: bgColor
@@ -431,7 +397,7 @@ If you want to embed overriding conditions directly within variations:
 variations:
   # ...
 
-  - value: true
+  - value: treatment
     weight: 100
     variables:
       - key: bgColor
@@ -459,7 +425,7 @@ variablesSchema:
 
 variations:
   # ...
-  - value: true
+  - value: treatment
     weight: 100
     variables:
       - key: bgColor
@@ -477,7 +443,7 @@ variablesSchema:
 
 variations:
   # ...
-  - value: true
+  - value: treatment
     weight: 100
     variables:
       - key: showSidebar
@@ -495,7 +461,7 @@ variablesSchema:
 
 variations:
   # ...
-  - value: true
+  - value: treatment
     weight: 100
     variables:
       - key: position
@@ -513,7 +479,7 @@ variablesSchema:
 
 variations:
   # ...
-  - value: true
+  - value: treatment
     weight: 100
     variables:
       - key: amount
@@ -533,7 +499,7 @@ variablesSchema:
 
 variations:
   # ...
-  - value: true
+  - value: treatment
     weight: 100
     variables:
       - key: acceptedCards
@@ -555,7 +521,7 @@ variablesSchema:
 
 variations:
   # ...
-  - value: true
+  - value: treatment
     weight: 100
     variables:
       - key: hero
@@ -575,7 +541,7 @@ variablesSchema:
 
 variations:
   # ...
-  - value: true
+  - value: treatment
     weight: 100
     variables:
       - key: hero
@@ -584,7 +550,7 @@ variations:
 
 ## Force
 
-You can force a feature to be enabled or disabled (or any another variation) against custom conditions.
+You can force a feature to be enabled or disabled against custom conditions.
 
 This is very useful when you wish to test something out quickly just for yourself in a specific environment without affecting any other users.
 
@@ -599,6 +565,9 @@ environments:
           - attribute: userId
             operator: equals
             value: "123"
+
+        # enable or disable it
+        enabled: true
 
         # forced variation
         variation: true

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -107,8 +107,6 @@ Learn more in [Segments](/docs/segments).
 
 We have come to the most interesting part now.
 
-### Boolean flags
-
 We can create a new `showBanner` feature, that controls a banner on our website:
 
 ```yml
@@ -120,17 +118,13 @@ tags:
 # this makes sure the same User ID consistently gets the same variation
 bucketBy: userId
 
-defaultVariation: false
-
-# boolean flags have only two variations: true and false
+# optionally add variations for running a/b tests
 variations:
-  - value: true
-    weight: 100 # out of a total of 100
+  - value: control
+    weight: 50 # out of a total of 100
 
-  # weight is 0 because it's boolean, and
-  # we can control the rollout percentage from environment rules below
-  - value: false
-    weight: 0
+  - value: treatment
+    weight: 50 # total sum of weights has to be 100
 
 environments:
   staging:
@@ -146,52 +140,6 @@ environments:
         segments:
           - "germany"
         percentage: 50
-
-      - key: "2"
-        segments: "*" # everyone
-        percentage: 0 # disabled for everyone else
-```
-
-### A/B test with variations
-
-Unlike boolean flags, A/B tests can have more than 2 variations, and they are of `string` type.
-
-Let's create a feature called `darkMode` which has 3 variations, and we wish to roll it out gradually in Germany first and then rest of the world.
-
-```yml
-# features/darkMode.yml
-description: Dark mode
-tags:
-  - all
-
-bucketBy: userId
-
-defaultVariation: light
-
-# three variations: light, dimmed, and dark.
-# sum of all weights must be 100
-variations:
-  - value: light
-    weight: 33.34
-
-  - value: dimmed
-    weight: 33.33
-
-  - value: dark
-    weight: 33.33
-
-environments:
-  staging:
-    rules:
-      - key: "1"
-        segments: "*"
-        percentage: 100
-  production:
-    rules:
-      - key: "1"
-        segments:
-          - "germany"
-        percentage: 100
 
       - key: "2"
         segments: "*" # everyone
@@ -295,7 +243,11 @@ const context = {
   country: "de",
 };
 
-const showBanner = sdk.getVariation(featureKey, context);
+// true or false
+const isBannerEnabled = sdk.isEnabled(featureKey, context);
+
+ // `control` or `treatment`
+const bannerVariation = sdk.getVariation(featureKey, context);
 ```
 
 Featurevisor SDK will take care of computing the right variation for you against the given `userId` and `country` attributes as context.

--- a/docs/sdks.md
+++ b/docs/sdks.md
@@ -89,9 +89,23 @@ const context = {
 };
 ```
 
+## Checking if enabled
+
+Once the SDK is initialized, you can check if a feature is enabled or not:
+
+```js
+const featureKey = "my_feature";
+const context = {
+  userId: "123",
+  country: "nl",
+};
+
+const isEnabled = sdk.isEnabled(featureKey, context);
+```
+
 ## Getting variations
 
-Once the SDK is initialized, you can get variations of your features as follows:
+If your feature has any variations defined, you can get evaluate them as follows:
 
 ```js
 const featureKey = "my_feature";
@@ -110,6 +124,53 @@ const variableKey = "bgColor";
 
 const bgColorValue = sdk.getVariable(featureKey, variableKey, context);
 ```
+
+## Type specific methods
+
+Next to generic `getVariable()` methods, there are also type specific methods available for convenience:
+
+### `boolean`
+
+```js
+sdk.getVariableBoolean(featureKey, variableKey, context);
+```
+
+### `string`
+
+```js
+sdk.getVariableString(featureKey, variableKey, context);
+```
+
+### `integer`
+
+```js
+sdk.getVariableInteger(featureKey, variableKey, context);
+```
+
+### `double`
+
+```js
+sdk.getVariableDouble(featureKey, variableKey, context);
+```
+
+### `array`
+
+```js
+sdk.getVariableArray(featureKey, variableKey, context);
+```
+
+### `object`
+
+```ts
+sdk.getVariableObject<T>(featureKey, variableKey, context);
+```
+
+### `json`
+
+```ts
+sdk.getVariableJSON<T>(featureKey, variableKey, context);
+```
+
 
 ## Activation
 
@@ -142,60 +203,6 @@ const variation = sdk.activate(featureKey, context);
 
 From the `onActivation` handler, you can send the activation event to your analytics service.
 
-## Type specific methods
-
-Next to generic `getVariation()`, `activate`, and `getVariable()` methods, there are also type specific methods for each of them:
-
-### `boolean`
-
-```js
-sdk.getVariationBoolean(featureKey, context);
-sdk.activateBoolean(featureKey, context);
-sdk.getVariableBoolean(featureKey, variableKey, context);
-```
-
-### `string`
-
-```js
-sdk.getVariationString(featureKey, context);
-sdk.activateString(featureKey, context);
-sdk.getVariableString(featureKey, variableKey, context);
-```
-
-### `integer`
-
-```js
-sdk.getVariationInteger(featureKey, context);
-sdk.activateInteger(featureKey, context);
-sdk.getVariableInteger(featureKey, variableKey, context);
-```
-
-### `double`
-
-```js
-sdk.getVariationDouble(featureKey, context);
-sdk.activateDouble(featureKey, context);
-sdk.getVariableDouble(featureKey, variableKey, context);
-```
-
-### `array`
-
-```js
-sdk.getVariableArray(featureKey, variableKey, context);
-```
-
-### `object`
-
-```ts
-sdk.getVariableObject<T>(featureKey, variableKey, context);
-```
-
-### `json`
-
-```ts
-sdk.getVariableJSON<T>(featureKey, variableKey, context);
-```
-
 ## Initial features
 
 You may want to initialize your SDK with a set of features before SDK has successfully fetched the datafile (if using `datafileUrl` option).
@@ -210,15 +217,16 @@ const sdk = createInstance({
 
   initialFeatures: {
     myFeatureKey: {
-      variation: true,
+      enabled: true,
 
-      // optional variables
+      // optional
+      variation: "treatment",
       variables: {
         myVariableKey: "myVariableValue",
       }
     },
     anotherFeatureKey: {
-      variation: false,
+      enabled: false,
     },
   },
 });
@@ -240,15 +248,16 @@ const sdk = createInstance({
 
   stickyFeatures: {
     myFeatureKey: {
-      variation: true,
+      enabled: true,
 
-      // optional variables
+      // optional
+      variation: "treatment",
       variables: {
         myVariableKey: "myVariableValue",
       }
     },
     anotherFeatureKey: {
-      variation: false,
+      enabled: false,
     }
   },
 });
@@ -261,11 +270,12 @@ You can also set sticky features after the SDK is initialized:
 ```js
 sdk.setStickyFeatures({
   myFeatureKey: {
-    variation: true,
+    enabled: true,
+    variation: "treatment",
     variables: {},
   },
   anotherFeatureKey: {
-    variation: false,
+    enabled: false,
   }
 });
 ```
@@ -527,6 +537,9 @@ sdk.removeAllListeners();
 Besides logging with debug level enabled, you can also get more details about how the feature variations and variables are evaluated in the runtime against given context:
 
 ```js
+// flag
+const evaluation = sdk.evaluateFlag(featureKey, context);
+
 // variation
 const evaluation = sdk.evaluateVariation(featureKey, context);
 
@@ -544,6 +557,7 @@ And optionally these properties depending on whether you are evaluating a featur
 - `bucketValue`: the bucket value between 0 and 100,000
 - `ruleKey`: the rule key
 - `error`: the error object
+- `enabled`: if feature itself is enabled or not
 - `variation`: the variation object
 - `variationValue`: the variation value
 - `variableKey`: the variable key

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -26,13 +26,19 @@ tests:
             at: 40
             context:
               country: nl
-            expectedVariation: false
+            expectedToBeEnabled: true
+
+            # if testing variations
+            expectedVariation: control
 
           # asserting evaluated variables
           - description: Testing variables at 90% in NL
             at: 90
             context:
               country: nl
+            expectedToBeEnabled: true
+
+            # if testing variables
             expectedVariables:
               someKey: someValue
 ```

--- a/docs/use-cases/entitlements.md
+++ b/docs/use-cases/entitlements.md
@@ -80,9 +80,6 @@ tags:
 
 bucketBy: userId
 
-# when we don't know better, we will always fall back to free plan
-defaultVariation: free
-
 # we define a variable called `entitlements`,
 # that will be an array of strings
 variablesSchema:
@@ -146,6 +143,7 @@ Set sticky features in the SDK for known user:
 // into the same plan (variation) as User Profile service suggests
 sdk.setStickyFeatures({
   plan: {
+    enabled: true,
     variation: userProfile.plan,
   },
 });
@@ -214,6 +212,7 @@ We can then use the `overrideEntitlements` field from User Profile and set it as
 ```js
 sdk.setStickyFeatures({
   plan: {
+    enabled: true,
     variation: userProfile.plan,
     variables: userProfile.overrideEntitlements
       // user overrides
@@ -278,8 +277,6 @@ tags:
   - all
 
 bucketBy: userId
-
-defaultVariation: free
 
 variablesSchema:
   - key: canLikePosts

--- a/docs/use-cases/experiments.md
+++ b/docs/use-cases/experiments.md
@@ -92,8 +92,6 @@ tags:
 
 bucketBy: deviceId
 
-defaultVariation: control
-
 variations:
   - value: control
     description: Original CTA button
@@ -226,8 +224,6 @@ tags:
   - all
 
 bucketBy: deviceId
-
-defaultVariation: control
 
 # define a schema of all variables
 # scoped under `hero` feature first

--- a/docs/use-cases/microfrontends.md
+++ b/docs/use-cases/microfrontends.md
@@ -160,16 +160,7 @@ description: Shows marketing banner at the bottom of the page
 tags:
   - <your-tag-here> # we will discuss this in next section below
 
-defaultVariation: false
-
 bucketBy: deviceId
-
-variations:
-  - value: true
-    weight: 100
-
-  - value: false
-    weight: 0
 
 environments:
   staging:
@@ -299,7 +290,7 @@ const context = {
   userId: "...",
 };
 
-const showMarketingBanner = sdk.getVariation(featureKey, context);
+const showMarketingBanner = sdk.isEnabled(featureKey, context);
 
 if (showMarketingBanner) {
   // render marketing banner

--- a/docs/use-cases/remote-configuration.md
+++ b/docs/use-cases/remote-configuration.md
@@ -63,16 +63,6 @@ tags:
 
 bucketBy: userId
 
-defaultVariation: false
-
-# we create a boolean variation for now
-variations:
-  - value: true
-    weight: 100
-
-  - value: false
-    weight: 0
-
 # rolled out as `true` to 100% of our traffic
 environments:
   production:
@@ -96,8 +86,6 @@ tags:
 
 bucketBy: userId
 
-defaultVariation: false
-
 # we add variable schema for all our parameters here,
 # starting with `paymentMethods` for now
 variablesSchema:
@@ -108,13 +96,6 @@ variablesSchema:
       - paypal
       - applePay
       - googlePay
-
-variations:
-  - value: true
-    weight: 100
-
-  - value: false
-    weight: 0
 
 environments:
   production:
@@ -282,8 +263,6 @@ tags:
 
 bucketBy: userId
 
-defaultVariation: false
-
 variablesSchema:
   - key: paymentMethods
     type: array
@@ -309,13 +288,6 @@ variablesSchema:
   - key: allowDiscountCode
     type: boolean
     defaultValue: false
-
-variations:
-  - value: true
-    weight: 100
-
-  - value: false
-    weight: 0
 
 environments:
   production:

--- a/docs/use-cases/remote-configuration.md
+++ b/docs/use-cases/remote-configuration.md
@@ -53,7 +53,7 @@ The [quick start](/docs/quick-start) can be very handy as a summary.
 
 ## Defining our feature
 
-We can start by creating a new feature called `checkout` that has boolean variations only for now:
+We can start by creating a new feature called `checkout`:
 
 ```yml
 # features/checkout.yml

--- a/docs/use-cases/testing-in-production.md
+++ b/docs/use-cases/testing-in-production.md
@@ -66,18 +66,6 @@ tags:
 # because this is only exposed to logged in users
 bucketBy: userId
 
-# by default, we want to disable this feature
-defaultValue: false
-
-variations:
-  - value: true
-    weight: 100
-
-  # boolean feature flags don't need any
-  # weight distribution for falsy value
-  - value: false
-    weight: 0
-
 environments:
   production:
     rules:
@@ -116,7 +104,7 @@ environments:
               - "user-id-3"
               - "user-id-4"
               - "user-id-5"
-        variation: true
+        enabled: true
     rules:
       - key: "1"
         segments: "*"
@@ -163,7 +151,7 @@ environments:
     force:
       - segments:
           - qa
-        variation: true # enabled for QA team members
+        enabled: true # enabled for QA team members
     rules:
       - key: "1"
         segments: "*"
@@ -197,7 +185,7 @@ const context = {
   deviceId: "device-id-1",
 };
 
-const isWishlistEnabled = sdk.getVariation(featureKey, context);
+const isWishlistEnabled = sdk.isEnabled(featureKey, context);
 
 if (isWishlistEnabled) {
   // render the wishlist feature

--- a/examples/example-1/features/bar.yml
+++ b/examples/example-1/features/bar.yml
@@ -4,8 +4,6 @@ tags:
 
 bucketBy: userId
 
-defaultVariation: control
-
 variablesSchema:
   - key: color
     type: string

--- a/examples/example-1/features/baz.yml
+++ b/examples/example-1/features/baz.yml
@@ -2,17 +2,7 @@ description: Classic on/off switch
 tags:
   - all
 
-defaultVariation: false
-
 bucketBy: userId
-
-variations:
-  - description: Enabled for all
-    value: true
-    weight: 100
-  - description: Disabled for all
-    value: false
-    weight: 0
 
 environments:
   staging:

--- a/examples/example-1/features/discount.yml
+++ b/examples/example-1/features/discount.yml
@@ -3,17 +3,7 @@ tags:
   - all
   - checkout
 
-defaultVariation: false
-
 bucketBy: userId
-
-variations:
-  - description: Enabled for all
-    value: true
-    weight: 100
-  - description: Disabled for all
-    value: false
-    weight: 0
 
 environments:
   staging:

--- a/examples/example-1/features/foo.yml
+++ b/examples/example-1/features/foo.yml
@@ -7,8 +7,6 @@ tags:
 
 bucketBy: userId
 
-defaultVariation: false
-
 variablesSchema:
   - key: bar
     type: string
@@ -18,9 +16,9 @@ variablesSchema:
     defaultValue: ""
 
 variations:
-  - value: false
+  - value: control
     weight: 50
-  - value: true
+  - value: treatment
     weight: 50
     variables:
       - key: bar
@@ -36,13 +34,23 @@ variations:
 
 environments:
   staging:
-    expose: true
     rules:
       - key: "1"
         segments: "*"
         percentage: 100
   production:
-    expose: true
+    force:
+      - conditions:
+          and:
+            - attribute: userId
+              operator: equals
+              value: "123"
+            - attribute: device
+              operator: equals
+              value: "mobile"
+        variation: treatment
+        variables:
+          bar: yoooooo
     rules:
       - key: "1"
         segments:
@@ -55,15 +63,3 @@ environments:
       - key: "2"
         segments: "*"
         percentage: 50
-    force:
-      - conditions:
-          and:
-            - attribute: userId
-              operator: equals
-              value: "123"
-            - attribute: device
-              operator: equals
-              value: "mobile"
-        variation: true
-        variables:
-          bar: yoooooo

--- a/examples/example-1/features/qux.yml
+++ b/examples/example-1/features/qux.yml
@@ -2,8 +2,6 @@ description: Variations with weights having decimal places
 tags:
   - all
 
-defaultVariation: control
-
 bucketBy: userId
 
 variablesSchema:

--- a/examples/example-1/features/sidebar.yml
+++ b/examples/example-1/features/sidebar.yml
@@ -4,8 +4,6 @@ tags:
 
 bucketBy: userId
 
-defaultVariation: false
-
 variablesSchema:
   - key: position
     type: string
@@ -21,9 +19,9 @@ variablesSchema:
     defaultValue: "Sidebar Title"
 
 variations:
-  - value: false
+  - value: control
     weight: 10
-  - value: true
+  - value: treatment
     weight: 90
     variables:
       - key: position

--- a/examples/example-1/featurevisor.config.js
+++ b/examples/example-1/featurevisor.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   environments: ["staging", "production"],
   tags: ["all", "checkout"],
+  prettyState: true,
 };

--- a/examples/example-1/package.json
+++ b/examples/example-1/package.json
@@ -9,7 +9,7 @@
     "test": "featurevisor test",
     "export": "featurevisor site export",
     "start": "npm run export && featurevisor site serve",
-    "generate-code": "featurevisor generate-code --language typescript --outputPath ./src"
+    "generate-code": "featurevisor generate-code --language typescript --out-dir ./src"
   },
   "dependencies": {
     "@featurevisor/cli": "^0.37.1"

--- a/examples/example-1/tests/bar.spec.yml
+++ b/examples/example-1/tests/bar.spec.yml
@@ -7,6 +7,7 @@ tests:
           - at: 15 # 30 * 0.5
             context:
               country: us
+            expectedToBeEnabled: true
             expectedVariation: control
             expectedVariables:
               color: red
@@ -18,6 +19,7 @@ tests:
           - at: 20 # 40 * 0.5
             context:
               country: us
+            expectedToBeEnabled: true
             expectedVariation: b
             expectedVariables:
               color: red
@@ -29,6 +31,7 @@ tests:
           - at: 20 # 40 * 0.5
             context:
               country: de
+            expectedToBeEnabled: true
             expectedVariation: b
             expectedVariables:
               color: red

--- a/examples/example-1/tests/baz.spec.yml
+++ b/examples/example-1/tests/baz.spec.yml
@@ -8,16 +8,16 @@ tests:
             description: "At 10%, the feature should be enabled"
             context:
               country: nl
-            expectedVariation: true
+            expectedToBeEnabled: true
 
           - at: 70
             description: "At 70%, the feature should be enabled"
             context:
               country: nl
-            expectedVariation: true
+            expectedToBeEnabled: true
 
           - at: 90
             description: "At 90%, the feature should be disabled"
             context:
               country: nl
-            expectedVariation: false
+            expectedToBeEnabled: false

--- a/examples/example-1/tests/discount.spec.yml
+++ b/examples/example-1/tests/discount.spec.yml
@@ -8,16 +8,16 @@ tests:
             description: "At 10%, the feature should be disabled on 1st January 2023"
             context:
               date: 2023-01-01T00:00:00Z
-            expectedVariation: false
+            expectedToBeEnabled: false
 
           - at: 70
             description: "At 70%, the feature should be disabled on 25th December 2023"
             context:
               date: 2023-12-25T00:00:00Z
-            expectedVariation: false
+            expectedToBeEnabled: false
 
           - at: 90
             description: "At 90%, the feature should be enabled on 25th November 2023"
             context:
               date: 2023-11-25T00:00:00Z
-            expectedVariation: true
+            expectedToBeEnabled: true

--- a/examples/example-1/tests/foo.spec.yml
+++ b/examples/example-1/tests/foo.spec.yml
@@ -7,22 +7,26 @@ tests:
           - at: 40
             context:
               country: de
-            expectedVariation: false
+            expectedToBeEnabled: true
+            expectedVariation: control
 
           - at: 60
             context:
               country: ch
-            expectedVariation: true
+            expectedToBeEnabled: true
+            expectedVariation: treatment
 
           - at: 60
             context:
               country: us
-            expectedVariation: true
+            expectedToBeEnabled: true
+            expectedVariation: treatment
 
           - at: 60
             context:
               country: us
-            expectedVariation: true
+            expectedToBeEnabled: true
+            expectedVariation: treatment
             expectedVariables:
               bar: bar_here
               baz: baz_here
@@ -30,7 +34,8 @@ tests:
           - at: 80
             context:
               country: de
-            expectedVariation: true
+            expectedToBeEnabled: true
+            expectedVariation: treatment
             expectedVariables:
               bar: bar for DE or CH
               baz: baz_here

--- a/examples/example-1/tests/qux.spec.yml
+++ b/examples/example-1/tests/qux.spec.yml
@@ -7,6 +7,7 @@ tests:
           - at: 66.5 # (33.33 * 0.5) + 50
             context:
               country: nl
+            expectedToBeEnabled: true
             expectedVariation: control
             expectedVariables:
               fooConfig:
@@ -15,16 +16,19 @@ tests:
           - at: 66.665 # (33.33 * 0.5) + 50
             context:
               country: nl
+            expectedToBeEnabled: true
             expectedVariation: control
 
           - at: 66.67 # (33.34 * 0.5) + 50
             context:
               country: nl
+            expectedToBeEnabled: true
             expectedVariation: control
 
           - at: 66.675 # (33.35 * 0.5) + 50
             context:
               country: nl
+            expectedToBeEnabled: true
             expectedVariation: b
             expectedVariables:
               fooConfig:
@@ -33,24 +37,29 @@ tests:
           - at: 67 # (42 * 0.5) + 50
             context:
               country: nl
+            expectedToBeEnabled: true
             expectedVariation: b
 
           - at: 83 # (66 * 0.5) + 50
             context:
               country: nl
+            expectedToBeEnabled: true
             expectedVariation: b
 
           - at: 83.5 # (67 * 0.5) + 50
             context:
               country: nl
+            expectedToBeEnabled: true
             expectedVariation: c
 
           - at: 95 # (90 * 0.5) + 50
             context:
               country: de
+            expectedToBeEnabled: true
             expectedVariation: b
 
           - at: 55 # (10 * 0.5) + 50
             context:
               country: de
+            expectedToBeEnabled: true
             expectedVariation: b

--- a/examples/example-1/tests/sidebar.spec.yml
+++ b/examples/example-1/tests/sidebar.spec.yml
@@ -7,17 +7,17 @@ tests:
           - at: 5
             context:
               country: nl
-            expectedVariation: false
+            expectedToBeEnabled: false
 
           - at: 90
             context:
               country: nl
-            expectedVariation: true
+            expectedToBeEnabled: true
 
           - at: 90
             context:
               country: nl
-            expectedVariation: true
+            expectedToBeEnabled: true
             expectedVariables:
               position: right
               color: red
@@ -25,7 +25,7 @@ tests:
           - at: 90
             context:
               country: de
-            expectedVariation: true
+            expectedToBeEnabled: true
             expectedVariables:
               position: right
               color: yellow
@@ -34,14 +34,14 @@ tests:
           - at: 90
             context:
               country: us
-            expectedVariation: true
+            expectedToBeEnabled: true
             expectedVariables:
               sections: ["home", "about", "contact"]
 
           - at: 90
             context:
               country: de
-            expectedVariation: true
+            expectedToBeEnabled: true
             expectedVariables:
               sections: ["home", "about", "contact", "imprint"]
 
@@ -49,6 +49,6 @@ tests:
             context:
               country: nl
               userId: "123"
-            expectedVariation: true
+            expectedToBeEnabled: true
             expectedVariables:
               sections: ["home", "about", "contact", "bitterballen"]

--- a/examples/example-1/tests/sidebar.spec.yml
+++ b/examples/example-1/tests/sidebar.spec.yml
@@ -7,17 +7,20 @@ tests:
           - at: 5
             context:
               country: nl
-            expectedToBeEnabled: false
+            expectedToBeEnabled: true
+            expectedVariation: control
 
           - at: 90
             context:
               country: nl
             expectedToBeEnabled: true
+            expectedVariation: treatment
 
           - at: 90
             context:
               country: nl
             expectedToBeEnabled: true
+            expectedVariation: treatment
             expectedVariables:
               position: right
               color: red
@@ -26,6 +29,7 @@ tests:
             context:
               country: de
             expectedToBeEnabled: true
+            expectedVariation: treatment
             expectedVariables:
               position: right
               color: yellow
@@ -35,6 +39,7 @@ tests:
             context:
               country: us
             expectedToBeEnabled: true
+            expectedVariation: treatment
             expectedVariables:
               sections: ["home", "about", "contact"]
 
@@ -42,6 +47,7 @@ tests:
             context:
               country: de
             expectedToBeEnabled: true
+            expectedVariation: treatment
             expectedVariables:
               sections: ["home", "about", "contact", "imprint"]
 
@@ -50,5 +56,6 @@ tests:
               country: nl
               userId: "123"
             expectedToBeEnabled: true
+            expectedVariation: treatment
             expectedVariables:
               sections: ["home", "about", "contact", "bitterballen"]

--- a/packages/core/src/generate-code/typescript.ts
+++ b/packages/core/src/generate-code/typescript.ts
@@ -182,7 +182,7 @@ import { getInstance } from "./instance";
 export namespace ${namespaceValue} {
   export const key = "${featureKey}";
 
-  export function isEnabled(context: Context {}) {
+  export function isEnabled(context: Context = {}) {
     return getInstance().isEnabled(key, context);
   }
 

--- a/packages/core/src/generate-code/typescript.ts
+++ b/packages/core/src/generate-code/typescript.ts
@@ -138,7 +138,7 @@ ${attributeProperties}
     const featureKey = path.basename(featureFile, ".yml");
     const parsedFeature = parseYaml(fs.readFileSync(featureFile, "utf8")) as ParsedFeature;
 
-    const variationType = getFeaturevisorTypeFromValue(parsedFeature.defaultVariation);
+    const variationType = "string";
     const variationTypeScriptType = convertFeaturevisorTypeToTypeScriptType(variationType);
 
     if (typeof parsedFeature.archived !== "undefined" && parsedFeature.archived) {
@@ -182,8 +182,12 @@ import { getInstance } from "./instance";
 export namespace ${namespaceValue} {
   export const key = "${featureKey}";
 
+  export function isEnabled(context: Context {}) {
+    return getInstance().isEnabled(key, context);
+  }
+
   export function getVariation(context: Context = {}) {
-    return getInstance().getVariation${getPascalCase(variationType)}(key, context);
+    return getInstance().getVariation(key, context);
   }${variableMethods}
 }
 `.trimStart();

--- a/packages/core/src/linter.ts
+++ b/packages/core/src/linter.ts
@@ -231,7 +231,7 @@ export function getFeatureJoiSchema(
           key: Joi.string(),
           segments: groupSegmentsJoiSchema,
           percentage: Joi.number().precision(3).min(0).max(100),
-          variation: variationValueJoiSchema.optional(),
+          variation: variationValueJoiSchema.optional(), // @TODO: only allowed if feature.variations is present
           variables: Joi.object().optional(), // @TODO: make it stricter
         }),
       )

--- a/packages/core/src/linter.ts
+++ b/packages/core/src/linter.ts
@@ -173,9 +173,10 @@ export function getFeatureJoiSchema(
   conditionsJoiSchema,
   availableSegmentKeys: string[],
 ) {
-  const variationValueJoiSchema = Joi.alternatives().try(Joi.string(), Joi.number(), Joi.boolean());
+  const variationValueJoiSchema = Joi.string().required();
   const variableValueJoiSchema = Joi.alternatives()
     .try(
+      // @TODO: make it stricter based on variableSchema.type
       Joi.string(),
       Joi.number(),
       Joi.boolean(),
@@ -269,8 +270,6 @@ export function getFeatureJoiSchema(
       )
       .required(),
 
-    defaultVariation: variationValueJoiSchema,
-
     bucketBy: Joi.alternatives()
       .try(
         // plain
@@ -331,23 +330,15 @@ export function getFeatureJoiSchema(
         }),
       )
       .custom((value, helpers) => {
-        var total = value.reduce((a, b) => a + b.weight, 0);
+        var total = value.reduce((a, b) => a.weight + b.weight, 0);
 
         if (total !== 100) {
           throw new Error(`Sum of all variation weights must be 100, got ${total}`);
         }
 
-        const typeOf = new Set(value.map((v) => typeof v.value));
-
-        if (typeOf.size > 1) {
-          throw new Error(
-            `All variations must have the same type, got ${Array.from(typeOf).join(", ")}`,
-          );
-        }
-
         return value;
       })
-      .required(),
+      .optional(),
 
     environments: allEnvironmentsJoiSchema.required(),
   });
@@ -382,7 +373,8 @@ export function getTestsJoiSchema(
                   at: Joi.number().precision(3).min(0).max(100),
                   context: Joi.object(),
 
-                  // @TODO: one or both below
+                  // @TODO: one or all below
+                  expectedToBeEnabled: Joi.boolean().required(),
                   expectedVariation: Joi.alternatives().try(
                     Joi.string(),
                     Joi.number(),

--- a/packages/core/src/linter.ts
+++ b/packages/core/src/linter.ts
@@ -231,6 +231,8 @@ export function getFeatureJoiSchema(
           key: Joi.string(),
           segments: groupSegmentsJoiSchema,
           percentage: Joi.number().precision(3).min(0).max(100),
+
+          enabled: Joi.boolean().optional(),
           variation: variationValueJoiSchema.optional(), // @TODO: only allowed if feature.variations is present
           variables: Joi.object().optional(), // @TODO: make it stricter
         }),
@@ -243,7 +245,8 @@ export function getFeatureJoiSchema(
         segments: groupSegmentsJoiSchema.optional(),
         conditions: conditionsJoiSchema.optional(),
 
-        variation: variationValueJoiSchema,
+        enabled: Joi.boolean().optional(),
+        variation: variationValueJoiSchema.optional(),
         variables: Joi.object().optional(), // @TODO: make it stricter
       }),
     ),

--- a/packages/core/src/linter.ts
+++ b/packages/core/src/linter.ts
@@ -330,7 +330,7 @@ export function getFeatureJoiSchema(
         }),
       )
       .custom((value, helpers) => {
-        var total = value.reduce((a, b) => a.weight + b.weight, 0);
+        var total = value.reduce((acc, v) => acc + v.weight, 0);
 
         if (total !== 100) {
           throw new Error(`Sum of all variation weights must be 100, got ${total}`);

--- a/packages/core/src/site.ts
+++ b/packages/core/src/site.ts
@@ -310,37 +310,39 @@ export function generateSiteSearchIndex(
       const fileContent = fs.readFileSync(filePath, "utf8");
       const parsed = parseYaml(fileContent) as ParsedFeature;
 
-      parsed.variations.forEach((variation) => {
-        if (!variation.variables) {
-          return;
-        }
-
-        variation.variables.forEach((v) => {
-          if (v.overrides) {
-            v.overrides.forEach((o) => {
-              if (o.conditions) {
-                extractAttributeKeysFromConditions(o.conditions).forEach((attributeKey) => {
-                  if (!attributesUsedInFeatures[attributeKey]) {
-                    attributesUsedInFeatures[attributeKey] = new Set();
-                  }
-
-                  attributesUsedInFeatures[attributeKey].add(entityName);
-                });
-              }
-
-              if (o.segments && o.segments !== "*") {
-                extractSegmentKeysFromGroupSegments(o.segments).forEach((segmentKey) => {
-                  if (!segmentsUsedInFeatures[segmentKey]) {
-                    segmentsUsedInFeatures[segmentKey] = new Set();
-                  }
-
-                  segmentsUsedInFeatures[segmentKey].add(entityName);
-                });
-              }
-            });
+      if (Array.isArray(parsed.variations)) {
+        parsed.variations.forEach((variation) => {
+          if (!variation.variables) {
+            return;
           }
+
+          variation.variables.forEach((v) => {
+            if (v.overrides) {
+              v.overrides.forEach((o) => {
+                if (o.conditions) {
+                  extractAttributeKeysFromConditions(o.conditions).forEach((attributeKey) => {
+                    if (!attributesUsedInFeatures[attributeKey]) {
+                      attributesUsedInFeatures[attributeKey] = new Set();
+                    }
+
+                    attributesUsedInFeatures[attributeKey].add(entityName);
+                  });
+                }
+
+                if (o.segments && o.segments !== "*") {
+                  extractSegmentKeysFromGroupSegments(o.segments).forEach((segmentKey) => {
+                    if (!segmentsUsedInFeatures[segmentKey]) {
+                      segmentsUsedInFeatures[segmentKey] = new Set();
+                    }
+
+                    segmentsUsedInFeatures[segmentKey].add(entityName);
+                  });
+                }
+              });
+            }
+          });
         });
-      });
+      }
 
       Object.keys(parsed.environments).forEach((environmentKey) => {
         const env = parsed.environments[environmentKey];

--- a/packages/core/src/tester.ts
+++ b/packages/core/src/tester.ts
@@ -118,7 +118,7 @@ export function testProject(rootDirectoryPath: string, projectConfig: ProjectCon
             }
           });
         });
-      } else {
+      } else if (test.environment && test.tag && test.features) {
         // feature testing
         const datafilePath = getDatafilePath(projectConfig, test.environment, test.tag);
 
@@ -157,6 +157,20 @@ export function testProject(rootDirectoryPath: string, projectConfig: ProjectCon
 
             let assertionHasError = false;
             currentAt = assertion.at * (MAX_BUCKETED_NUMBER / 100);
+
+            // isEnabled
+            if ("expectedToBeEnabled" in assertion) {
+              const isEnabled = sdk.isEnabled(featureKey, assertion.context);
+
+              if (isEnabled !== assertion.expectedToBeEnabled) {
+                hasError = true;
+                assertionHasError = true;
+
+                console.error(
+                  `           isEnabled failed: expected "${assertion.expectedToBeEnabled}", got "${isEnabled}"`,
+                );
+              }
+            }
 
             // variation
             if ("expectedVariation" in assertion) {
@@ -203,6 +217,9 @@ export function testProject(rootDirectoryPath: string, projectConfig: ProjectCon
             }
           });
         });
+      } else {
+        console.error(`     => Invalid test: ${JSON.stringify(test)}`);
+        hasError = true;
       }
     });
   }

--- a/packages/react/src/activateFeature.spec.tsx
+++ b/packages/react/src/activateFeature.spec.tsx
@@ -14,17 +14,16 @@ function getNewInstance() {
       features: [
         {
           key: "test",
-          defaultVariation: false,
           bucketBy: "userId",
-          variations: [{ value: true }, { value: false }],
+          variations: [{ value: "control" }, { value: "treatment" }],
           traffic: [
             {
               key: "1",
               segments: "*",
               percentage: 100000,
               allocation: [
-                { variation: true, range: [0, 100000] },
-                { variation: false, range: [0, 0] },
+                { variation: "control", range: [0, 100000] },
+                { variation: "treatment", range: [0, 0] },
               ],
             },
           ],
@@ -47,7 +46,7 @@ describe("react: activateFeature", function () {
     function TestComponent() {
       const variation = activateFeature("test", { userId: "1" });
 
-      return variation === true ? <p>True</p> : <p>False</p>;
+      return variation === "control" ? <p>True</p> : <p>False</p>;
     }
 
     render(

--- a/packages/react/src/useSdk.spec.tsx
+++ b/packages/react/src/useSdk.spec.tsx
@@ -14,17 +14,16 @@ function getNewInstance() {
       features: [
         {
           key: "test",
-          defaultVariation: false,
           bucketBy: "userId",
-          variations: [{ value: true }, { value: false }],
+          variations: [{ value: "control" }, { value: "treatment" }],
           traffic: [
             {
               key: "1",
               segments: "*",
               percentage: 100000,
               allocation: [
-                { variation: true, range: [0, 100000] },
-                { variation: false, range: [0, 0] },
+                { variation: "control", range: [0, 100000] },
+                { variation: "treatment", range: [0, 0] },
               ],
             },
           ],

--- a/packages/react/src/useStatus.spec.tsx
+++ b/packages/react/src/useStatus.spec.tsx
@@ -14,17 +14,16 @@ function getNewInstance() {
       features: [
         {
           key: "test",
-          defaultVariation: false,
           bucketBy: "userId",
-          variations: [{ value: true }, { value: false }],
+          variations: [{ value: "control" }, { value: "treatment" }],
           traffic: [
             {
               key: "1",
               segments: "*",
               percentage: 100000,
               allocation: [
-                { variation: true, range: [0, 100000] },
-                { variation: false, range: [0, 0] },
+                { variation: "control", range: [0, 100000] },
+                { variation: "treatment", range: [0, 0] },
               ],
             },
           ],

--- a/packages/react/src/useVariable.spec.tsx
+++ b/packages/react/src/useVariable.spec.tsx
@@ -14,7 +14,6 @@ function getNewInstance() {
       features: [
         {
           key: "test",
-          defaultVariation: "control",
           bucketBy: "userId",
           variations: [{ value: "control" }, { value: "b" }, { value: "c" }],
           traffic: [

--- a/packages/react/src/useVariation.spec.tsx
+++ b/packages/react/src/useVariation.spec.tsx
@@ -14,17 +14,16 @@ function getNewInstance() {
       features: [
         {
           key: "test",
-          defaultVariation: false,
           bucketBy: "userId",
-          variations: [{ value: true }, { value: false }],
+          variations: [{ value: "control" }, { value: "treatment" }],
           traffic: [
             {
               key: "1",
               segments: "*",
               percentage: 100000,
               allocation: [
-                { variation: true, range: [0, 100000] },
-                { variation: false, range: [0, 0] },
+                { variation: "control", range: [0, 100000] },
+                { variation: "treatment", range: [0, 0] },
               ],
             },
           ],
@@ -47,7 +46,7 @@ describe("react: useVariation", function () {
     function TestComponent() {
       const variation = useVariation("test", { userId: "1" });
 
-      return variation === true ? <p>True</p> : <p>False</p>;
+      return variation === "control" ? <p>True</p> : <p>False</p>;
     }
 
     render(

--- a/packages/sdk/src/feature.ts
+++ b/packages/sdk/src/feature.ts
@@ -19,6 +19,26 @@ export function getMatchedAllocation(
   return undefined;
 }
 
+export function getMatchedTraffic(
+  traffic: Traffic[],
+  context: Context,
+  datafileReader: DatafileReader,
+): Traffic | undefined {
+  return traffic.find((t) => {
+    if (
+      !allGroupSegmentsAreMatched(
+        typeof t.segments === "string" && t.segments !== "*" ? JSON.parse(t.segments) : t.segments,
+        context,
+        datafileReader,
+      )
+    ) {
+      return false;
+    }
+
+    return true;
+  });
+}
+
 export interface MatchedTrafficAndAllocation {
   matchedTraffic: Traffic | undefined;
   matchedAllocation: Allocation | undefined;

--- a/packages/sdk/src/instance.spec.ts
+++ b/packages/sdk/src/instance.spec.ts
@@ -83,7 +83,7 @@ describe("sdk: instance", function () {
       userId: "123",
     });
 
-    expect(variation).toEqual(true);
+    expect(variation).toEqual("control");
     expect(capturedBucketKey).toEqual("123.test");
   });
 
@@ -127,7 +127,7 @@ describe("sdk: instance", function () {
       organizationId: "456",
     });
 
-    expect(variation).toEqual(true);
+    expect(variation).toEqual("control");
     expect(capturedBucketKey).toEqual("123.456.test");
   });
 
@@ -171,14 +171,14 @@ describe("sdk: instance", function () {
         userId: "123",
         deviceId: "456",
       }),
-    ).toEqual(true);
+    ).toEqual("control");
     expect(capturedBucketKey).toEqual("123.test");
 
     expect(
       sdk.getVariation("test", {
         deviceId: "456",
       }),
-    ).toEqual(true);
+    ).toEqual("control");
     expect(capturedBucketKey).toEqual("456.test");
   });
 
@@ -223,7 +223,7 @@ describe("sdk: instance", function () {
       userId: "123",
     });
 
-    expect(variation).toEqual(true);
+    expect(variation).toEqual("control");
     expect(intercepted).toEqual(true);
   });
 
@@ -265,14 +265,14 @@ describe("sdk: instance", function () {
     });
 
     expect(activated).toEqual(false);
-    expect(variation).toEqual(true);
+    expect(variation).toEqual("control");
 
     const activatedVariation = sdk.activate("test", {
       userId: "123",
     });
 
     expect(activated).toEqual(true);
-    expect(activatedVariation).toEqual(true);
+    expect(activatedVariation).toEqual("control");
   });
 
   it("should refresh datafile", function (done) {
@@ -365,8 +365,8 @@ describe("sdk: instance", function () {
                   segments: "*",
                   percentage: 100000,
                   allocation: [
-                    { variation: "control", range: [0, 100000] },
-                    { variation: "treatment", range: [0, 0] },
+                    { variation: "control", range: [0, 0] },
+                    { variation: "treatment", range: [0, 100000] },
                   ],
                 },
               ],
@@ -389,7 +389,7 @@ describe("sdk: instance", function () {
       sdk.getVariation("test", {
         userId: "123",
       }),
-    ).toEqual(false);
+    ).toEqual("control");
 
     setTimeout(function () {
       // still false after fetching datafile
@@ -397,7 +397,7 @@ describe("sdk: instance", function () {
         sdk.getVariation("test", {
           userId: "123",
         }),
-      ).toEqual(false);
+      ).toEqual("control");
 
       // unsetting sticky features will make it true
       sdk.setStickyFeatures({});
@@ -405,7 +405,7 @@ describe("sdk: instance", function () {
         sdk.getVariation("test", {
           userId: "123",
         }),
-      ).toEqual(true);
+      ).toEqual("treatment");
 
       done();
     }, 75);
@@ -435,8 +435,8 @@ describe("sdk: instance", function () {
                   segments: "*",
                   percentage: 100000,
                   allocation: [
-                    { variation: "control", range: [0, 100000] },
-                    { variation: "treatment", range: [0, 0] },
+                    { variation: "control", range: [0, 0] },
+                    { variation: "treatment", range: [0, 100000] },
                   ],
                 },
               ],
@@ -459,7 +459,7 @@ describe("sdk: instance", function () {
       sdk.getVariation("test", {
         userId: "123",
       }),
-    ).toEqual(false);
+    ).toEqual("control");
 
     setTimeout(function () {
       // true after fetching datafile
@@ -467,7 +467,7 @@ describe("sdk: instance", function () {
         sdk.getVariation("test", {
           userId: "123",
         }),
-      ).toEqual(true);
+      ).toEqual("treatment");
 
       done();
     }, 75);

--- a/packages/sdk/src/instance.spec.ts
+++ b/packages/sdk/src/instance.spec.ts
@@ -54,17 +54,16 @@ describe("sdk: instance", function () {
         features: [
           {
             key: "test",
-            defaultVariation: false,
             bucketBy: "userId",
-            variations: [{ value: true }, { value: false }],
+            variations: [{ value: "control" }, { value: "treatment" }],
             traffic: [
               {
                 key: "1",
                 segments: "*",
                 percentage: 100000,
                 allocation: [
-                  { variation: true, range: [0, 100000] },
-                  { variation: false, range: [0, 0] },
+                  { variation: "control", range: [0, 100000] },
+                  { variation: "treatment", range: [0, 0] },
                 ],
               },
             ],
@@ -98,17 +97,16 @@ describe("sdk: instance", function () {
         features: [
           {
             key: "test",
-            defaultVariation: false,
             bucketBy: ["userId", "organizationId"],
-            variations: [{ value: true }, { value: false }],
+            variations: [{ value: "control" }, { value: "treatment" }],
             traffic: [
               {
                 key: "1",
                 segments: "*",
                 percentage: 100000,
                 allocation: [
-                  { variation: true, range: [0, 100000] },
-                  { variation: false, range: [0, 0] },
+                  { variation: "control", range: [0, 100000] },
+                  { variation: "treatment", range: [0, 0] },
                 ],
               },
             ],
@@ -143,17 +141,16 @@ describe("sdk: instance", function () {
         features: [
           {
             key: "test",
-            defaultVariation: false,
             bucketBy: { or: ["userId", "deviceId"] },
-            variations: [{ value: true }, { value: false }],
+            variations: [{ value: "control" }, { value: "treatment" }],
             traffic: [
               {
                 key: "1",
                 segments: "*",
                 percentage: 100000,
                 allocation: [
-                  { variation: true, range: [0, 100000] },
-                  { variation: false, range: [0, 0] },
+                  { variation: "control", range: [0, 100000] },
+                  { variation: "treatment", range: [0, 0] },
                 ],
               },
             ],
@@ -195,17 +192,16 @@ describe("sdk: instance", function () {
         features: [
           {
             key: "test",
-            defaultVariation: false,
             bucketBy: "userId",
-            variations: [{ value: true }, { value: false }],
+            variations: [{ value: "control" }, { value: "treatment" }],
             traffic: [
               {
                 key: "1",
                 segments: "*",
                 percentage: 100000,
                 allocation: [
-                  { variation: true, range: [0, 100000] },
-                  { variation: false, range: [0, 0] },
+                  { variation: "control", range: [0, 100000] },
+                  { variation: "treatment", range: [0, 0] },
                 ],
               },
             ],
@@ -241,17 +237,16 @@ describe("sdk: instance", function () {
         features: [
           {
             key: "test",
-            defaultVariation: false,
             bucketBy: "userId",
-            variations: [{ value: true }, { value: false }],
+            variations: [{ value: "control" }, { value: "treatment" }],
             traffic: [
               {
                 key: "1",
                 segments: "*",
                 percentage: 100000,
                 allocation: [
-                  { variation: true, range: [0, 100000] },
-                  { variation: false, range: [0, 0] },
+                  { variation: "control", range: [0, 100000] },
+                  { variation: "treatment", range: [0, 0] },
                 ],
               },
             ],
@@ -292,17 +287,16 @@ describe("sdk: instance", function () {
         features: [
           {
             key: "test",
-            defaultVariation: false,
             bucketBy: "userId",
-            variations: [{ value: true }, { value: false }],
+            variations: [{ value: "control" }, { value: "treatment" }],
             traffic: [
               {
                 key: "1",
                 segments: "*",
                 percentage: 100000,
                 allocation: [
-                  { variation: true, range: [0, 100000] },
-                  { variation: false, range: [0, 0] },
+                  { variation: "control", range: [0, 100000] },
+                  { variation: "treatment", range: [0, 0] },
                 ],
               },
             ],
@@ -351,7 +345,8 @@ describe("sdk: instance", function () {
     const sdk = createInstance({
       stickyFeatures: {
         test: {
-          variation: false,
+          enabled: true,
+          variation: "control",
         },
       },
       datafileUrl: "http://localhost:3000/datafile.json",
@@ -362,17 +357,16 @@ describe("sdk: instance", function () {
           features: [
             {
               key: "test",
-              defaultVariation: false,
               bucketBy: "userId",
-              variations: [{ value: true }, { value: false }],
+              variations: [{ value: "control" }, { value: "treatment" }],
               traffic: [
                 {
                   key: "1",
                   segments: "*",
                   percentage: 100000,
                   allocation: [
-                    { variation: true, range: [0, 100000] },
-                    { variation: false, range: [0, 0] },
+                    { variation: "control", range: [0, 100000] },
+                    { variation: "treatment", range: [0, 0] },
                   ],
                 },
               ],
@@ -421,7 +415,8 @@ describe("sdk: instance", function () {
     const sdk = createInstance({
       initialFeatures: {
         test: {
-          variation: false,
+          enabled: true,
+          variation: "control",
         },
       },
       datafileUrl: "http://localhost:3000/datafile.json",
@@ -432,17 +427,16 @@ describe("sdk: instance", function () {
           features: [
             {
               key: "test",
-              defaultVariation: false,
               bucketBy: "userId",
-              variations: [{ value: true }, { value: false }],
+              variations: [{ value: "control" }, { value: "treatment" }],
               traffic: [
                 {
                   key: "1",
                   segments: "*",
                   percentage: 100000,
                   allocation: [
-                    { variation: true, range: [0, 100000] },
-                    { variation: false, range: [0, 0] },
+                    { variation: "control", range: [0, 100000] },
+                    { variation: "treatment", range: [0, 0] },
                   ],
                 },
               ],

--- a/packages/sdk/src/instance.spec.ts
+++ b/packages/sdk/src/instance.spec.ts
@@ -79,11 +79,13 @@ describe("sdk: instance", function () {
       },
     });
 
-    const variation = sdk.getVariation("test", {
+    const featureKey = "test";
+    const context = {
       userId: "123",
-    });
+    };
 
-    expect(variation).toEqual("control");
+    expect(sdk.isEnabled(featureKey, context)).toEqual(true);
+    expect(sdk.getVariation(featureKey, context)).toEqual("control");
     expect(capturedBucketKey).toEqual("123.test");
   });
 
@@ -122,12 +124,13 @@ describe("sdk: instance", function () {
       },
     });
 
-    const variation = sdk.getVariation("test", {
+    const featureKey = "test";
+    const context = {
       userId: "123",
       organizationId: "456",
-    });
+    };
 
-    expect(variation).toEqual("control");
+    expect(sdk.getVariation(featureKey, context)).toEqual("control");
     expect(capturedBucketKey).toEqual("123.456.test");
   });
 
@@ -166,6 +169,12 @@ describe("sdk: instance", function () {
       },
     });
 
+    expect(
+      sdk.isEnabled("test", {
+        userId: "123",
+        deviceId: "456",
+      }),
+    ).toEqual(true);
     expect(
       sdk.getVariation("test", {
         userId: "123",
@@ -384,7 +393,7 @@ describe("sdk: instance", function () {
       },
     });
 
-    // initially false
+    // initially control
     expect(
       sdk.getVariation("test", {
         userId: "123",
@@ -392,14 +401,14 @@ describe("sdk: instance", function () {
     ).toEqual("control");
 
     setTimeout(function () {
-      // still false after fetching datafile
+      // still control after fetching datafile
       expect(
         sdk.getVariation("test", {
           userId: "123",
         }),
       ).toEqual("control");
 
-      // unsetting sticky features will make it true
+      // unsetting sticky features will make it treatment
       sdk.setStickyFeatures({});
       expect(
         sdk.getVariation("test", {
@@ -454,7 +463,7 @@ describe("sdk: instance", function () {
       },
     });
 
-    // initially false
+    // initially control
     expect(
       sdk.getVariation("test", {
         userId: "123",
@@ -462,7 +471,7 @@ describe("sdk: instance", function () {
     ).toEqual("control");
 
     setTimeout(function () {
-      // true after fetching datafile
+      // treatment after fetching datafile
       expect(
         sdk.getVariation("test", {
           userId: "123",

--- a/packages/sdk/src/instance.ts
+++ b/packages/sdk/src/instance.ts
@@ -546,6 +546,7 @@ export class FeaturevisorInstance {
 
         // treated as enabled because of matched traffic
         if (bucketValue < matchedTraffic.percentage) {
+          // @TODO: verify if range check should be inclusive or not
           evaluation = {
             featureKey: feature.key,
             reason: EvaluationReason.RULE,

--- a/packages/sdk/src/instance.ts
+++ b/packages/sdk/src/instance.ts
@@ -533,6 +533,8 @@ export class FeaturevisorInstance {
           ruleKey: matchedTraffic.key,
           traffic: matchedTraffic,
         };
+
+        return evaluation;
       }
 
       // nothing matched

--- a/packages/sdk/src/instance.ts
+++ b/packages/sdk/src/instance.ts
@@ -80,6 +80,7 @@ export type DatafileFetchHandler = (datafileUrl: string) => Promise<DatafileCont
 export enum EvaluationReason {
   NOT_FOUND = "not_found",
   NO_VARIATIONS = "no_variations",
+  DISABLED = "disabled",
   OUT_OF_RANGE = "out_of_range",
   FORCED = "forced",
   INITIAL = "initial",
@@ -614,6 +615,19 @@ export class FeaturevisorInstance {
     try {
       const key = typeof featureKey === "string" ? featureKey : featureKey.key;
 
+      const flag = this.evaluateFlag(featureKey, context);
+
+      if (flag.enabled === false) {
+        evaluation = {
+          featureKey: key,
+          reason: EvaluationReason.DISABLED,
+        };
+
+        this.logger.debug("feature is disabled", evaluation);
+
+        return evaluation;
+      }
+
       // sticky
       if (this.stickyFeatures && this.stickyFeatures[key]) {
         const variationValue = this.stickyFeatures[key].variation;
@@ -874,6 +888,19 @@ export class FeaturevisorInstance {
 
     try {
       const key = typeof featureKey === "string" ? featureKey : featureKey.key;
+
+      const flag = this.evaluateFlag(featureKey, context);
+
+      if (flag.enabled === false) {
+        evaluation = {
+          featureKey: key,
+          reason: EvaluationReason.DISABLED,
+        };
+
+        this.logger.debug("feature is disabled", evaluation);
+
+        return evaluation;
+      }
 
       // sticky
       if (this.stickyFeatures && this.stickyFeatures[key]) {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -96,8 +96,7 @@ export type AndOrNotGroupSegment = AndGroupSegment | OrGroupSegment | NotGroupSe
 // group of segment keys with and/or conditions, or just string
 export type GroupSegment = PlainGroupSegment | AndOrNotGroupSegment;
 
-export type VariationType = "boolean" | "string" | "integer" | "double";
-export type VariationValue = boolean | string | number | null | undefined;
+export type VariationValue = string;
 
 export type VariableKey = string;
 export type VariableType =
@@ -245,7 +244,8 @@ export interface DatafileContent {
 
 export interface StickyFeatures {
   [key: FeatureKey]: {
-    variation: VariationValue;
+    enabled: boolean;
+    variation?: VariationValue;
     variables?: {
       [key: VariableKey]: VariableValue;
     };
@@ -288,9 +288,8 @@ export interface ParsedFeature {
 
   bucketBy: BucketBy;
 
-  defaultVariation: VariationValue;
   variablesSchema?: VariableSchema[];
-  variations: Variation[];
+  variations?: Variation[];
 
   environments: {
     [key: EnvironmentKey]: Environment;
@@ -303,7 +302,7 @@ export interface ParsedFeature {
  * with consistent bucketing
  */
 export interface ExistingFeature {
-  variations: {
+  variations?: {
     // @TODO: use Exclude with Variation?
     value: VariationValue;
     weight: Weight;
@@ -332,6 +331,7 @@ export interface FeatureAssertion {
   description?: string;
   at: Weight; // bucket weight: 0 to 100
   context: Context;
+  expectedToBeEnabled: boolean;
   expectedVariation?: VariationValue;
   expectedVariables?: {
     [key: VariableKey]: VariableValue;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -235,6 +235,7 @@ export interface Feature {
   bucketBy: BucketBy;
   traffic: Traffic[];
   force?: Force[];
+  ranges?: Range[]; // if in a Group (mutex), these are the available slot ranges
 }
 
 export interface DatafileContent {
@@ -320,7 +321,7 @@ export interface ExistingFeature {
     percentage: Percentage;
     allocation: Allocation[];
   }[];
-  ranges?: Range[]; // if in a Group, these are the available slot ranges
+  ranges?: Range[]; // if in a Group (mutex), these are the available slot ranges
 }
 
 export interface ExistingFeatures {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -173,7 +173,8 @@ export interface Force {
   conditions?: Condition | Condition[];
   segments?: GroupSegment | GroupSegment[];
 
-  variation: VariationValue;
+  enabled?: boolean;
+  variation?: VariationValue;
   variables?: {
     [key: string]: VariableValue;
   };
@@ -209,10 +210,13 @@ export interface Traffic {
   key: RuleKey;
   segments: GroupSegment | GroupSegment[] | "*";
   percentage: Percentage;
+
+  enabled?: boolean;
   variation?: VariationValue;
   variables?: {
     [key: string]: VariableValue;
   };
+
   allocation: Allocation[];
 }
 
@@ -241,14 +245,16 @@ export interface DatafileContent {
   features: Feature[];
 }
 
-export interface StickyFeatures {
-  [key: FeatureKey]: {
-    enabled: boolean;
-    variation?: VariationValue;
-    variables?: {
-      [key: VariableKey]: VariableValue;
-    };
+export interface OverrideFeature {
+  enabled: boolean;
+  variation?: VariationValue;
+  variables?: {
+    [key: VariableKey]: VariableValue;
   };
+}
+
+export interface StickyFeatures {
+  [key: FeatureKey]: OverrideFeature;
 }
 
 export type InitialFeatures = StickyFeatures;
@@ -266,6 +272,8 @@ export interface Rule {
   key: RuleKey;
   segments: GroupSegment | GroupSegment[];
   percentage: Weight;
+
+  enabled?: boolean;
   variation?: VariationValue;
   variables?: {
     [key: string]: VariableValue;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -226,9 +226,8 @@ export type BucketBy = PlainBucketBy | AndBucketBy | OrBucketBy;
 export interface Feature {
   key: FeatureKey;
   // @TODO: introduce new `parent` key?
-  defaultVariation: VariationValue;
   variablesSchema?: VariableSchema[];
-  variations: Variation[];
+  variations?: Variation[];
   bucketBy: BucketBy;
   traffic: Traffic[];
   force?: Force[];

--- a/packages/vue/src/index.spec.ts
+++ b/packages/vue/src/index.spec.ts
@@ -14,17 +14,16 @@ describe("vue: index", function () {
         features: [
           {
             key: "test",
-            defaultVariation: false,
             bucketBy: "userId",
-            variations: [{ value: true }, { value: false }],
+            variations: [{ value: "control" }, { value: "treatment" }],
             traffic: [
               {
                 key: "1",
                 segments: "*",
                 percentage: 100000,
                 allocation: [
-                  { variation: true, range: [0, 100000] },
-                  { variation: false, range: [0, 0] },
+                  { variation: "control", range: [0, 100000] },
+                  { variation: "treatment", range: [0, 0] },
                 ],
               },
             ],


### PR DESCRIPTION
## What's done

This PR has changed some fundamental concepts of Featurevisor, making things more explicit and easy to understand for everyone.

## Variations

### Before

- 2 types of feature evaluations only: variations and variables
- `defaultVariation` is required in features
- `variations` could be of booleans or string types

### After

- 3 types of feature evaluations: enabled, variations, and variables
- `defaultVariation` is redundant
- `variations` can be of string type only
- check if feature itself is enabled or not separately

## Boolean feature example

### Before

We had to define boolean features with true/false variations, which was too verbose.

```yml
# features/showBanner.yml
description: banner
tags: 
  - all

bucketBy: userId

defaultVariation: false

variations:
  - value: true
    weight: 100

  - value: false
    weight: 0

environments:
  production:
    rules:
      - key: "1"
        segments: "*"
        percentage: 100
```

### After

Enabled/disabled is a state of its own now irrespective a feature's variations, therefore we don't need to declare them unless we really want (string) variations.

```yml
# features/showBanner.yml
description: banner
tags: 
  - all

bucketBy: userId

environments:
  production:
    rules:
      - key: "1"
        segments: "*"
        percentage: 100
```

## SDK usage

### Before

Same method for checking if feature is enabled or not

```js
const isEnabled = sdk.getVariation(featureKey, context) === true;
```

### After

Separate methods with explicit types:

```js
// always available
const isEnabled = sdk.isEnabled(featureKey, context); // boolean

// if feature has variations, then:
const variation = sdk.getVariation(featureKey, context); // string
```

## Variables

Unaffected.

## Force

### Before

```yml
# features/showBanner.yml

# ...

environments:
  production:
    force:
      - segments: "*" # or direct embedded conditions
        variation: true
    rules:
      - key: "1"
        segments: "*"
        percentage: 100
```

### After

```yml
# features/showBanner.yml

# ...

environments:
  production:
    force:
      - segments: "*" # or direct embedded conditions
        enabled: true # or false
       
        # optional
        variation: treatment
        variables:
          key: value
    rules:
      - key: "1"
        segments: "*"
        percentage: 100
```

## SDK evaluations

If feature itself is not evaluated to be enabled:

```js
const isEnabled = sdk.isEnabled(featureKey, context);
```

Then `getVariation()` and `getVariable()` methods will return `undefined`.