### PR TITLE
feat: segment testing assertion property updated

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -9,7 +9,7 @@ Features and segments can grow into complex configuration very fast, and it's im
 
 You can write test specs in YAML to test your features in great detail.
 
-Create a new test spec in `tests` directory:
+Assuming we already have a `foo` feature in `features/foo.yml`, we can create a new test spec for it in `tests` directory:
 
 ```yml
 # tests/foo.spec.yml
@@ -73,12 +73,12 @@ tests:
           - description: Testing segment in NL
             context:
               country: nl
-            expected: true
+            expectedToMatch: true
 
           - description: Testing segment in DE
             context:
               country: de
-            expected: false
+            expectedToMatch: false
 ```
 
 ## Running tests

--- a/examples/example-1/tests/germany.spec.yml
+++ b/examples/example-1/tests/germany.spec.yml
@@ -4,13 +4,13 @@ tests:
         assertions:
           - context:
               country: de
-            expected: true
+            expectedToMatch: true
 
           - context:
               country: de
               someOtherAttribute: someOtherValue
-            expected: true
+            expectedToMatch: true
 
           - context:
               country: notDe
-            expected: false
+            expectedToMatch: false

--- a/packages/core/src/linter.ts
+++ b/packages/core/src/linter.ts
@@ -415,7 +415,7 @@ export function getTestsJoiSchema(
               Joi.object({
                 description: Joi.string().optional(),
                 context: Joi.object(),
-                expected: Joi.boolean(),
+                expectedToMatch: Joi.boolean(),
               }),
             ),
           }),

--- a/packages/core/src/tester.ts
+++ b/packages/core/src/tester.ts
@@ -107,7 +107,7 @@ export function testProject(rootDirectoryPath: string, projectConfig: ProjectCon
 
             let assertionHasError = false;
 
-            const expected = assertion.expected;
+            const expected = assertion.expectedToMatch;
             const actual = allConditionsAreMatched(conditions, assertion.context);
 
             if (actual !== expected) {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -363,7 +363,7 @@ export interface TestFeature {
 export interface SegmentAssertion {
   description?: string;
   context: Context;
-  expected: boolean;
+  expectedToMatch: boolean;
 }
 
 export interface TestSegment {


### PR DESCRIPTION
## What's done

In segments' test specs, `expected` has been renamed to `expectedTomatch`.

## Comparison

### Before

```yml
# tests/germany.spec.yml
tests:
  - segments:
      - key: germany
        assertions:
          - context:
              country: de
            expected: true # notice this line
```

### After

```yml
tests:
  - segments:
      - key: germany
        assertions:
          - context:
              country: de
            expectedToMatch: true # renamed property here
```