### PR TITLE
feat: make getFeature() method public

### DIFF
--- a/packages/sdk/src/instance.ts
+++ b/packages/sdk/src/instance.ts
@@ -283,7 +283,7 @@ export class FeaturevisorInstance {
     return this.datafileReader.getRevision();
   }
 
-  private getFeature(featureKey: string | Feature): Feature | undefined {
+  getFeature(featureKey: string | Feature): Feature | undefined {
     return typeof featureKey === "string"
       ? this.datafileReader.getFeature(featureKey) // only key provided
       : featureKey; // full feature provided


### PR DESCRIPTION
## What's done

We already had a `getFeature()` method that was private to the SDK instance itself.

Now it is made public, and others can call it as:

```js
sdk.getFeature(featureKey);
```

This will give you the Feature object as found in the datafile, otherwise `undefined`.