### PR TITLE
fix: useStatus React hook

### DIFF
--- a/packages/react/src/useStatus.ts
+++ b/packages/react/src/useStatus.ts
@@ -12,10 +12,6 @@ export function useStatus(): Status {
 
   const [isReady, setIsReady] = React.useState(initialStatus);
 
-  if (isReady) {
-    return { isReady };
-  }
-
   React.useEffect(function () {
     function handleReady() {
       setIsReady(true);


### PR DESCRIPTION
Ended up with this error when trying to implement Featurevisor SDK in a fresh new React app: https://stackoverflow.com/questions/53472795/uncaught-error-rendered-fewer-hooks-than-expected-this-may-be-caused-by-an-acc

Removing the early return fixed the problem for `useStatus` hoko.