### PR TITLE
feat: React provider component prop renamed from sdk to instance

### DIFF
--- a/docs/react.md
+++ b/docs/react.md
@@ -25,12 +25,12 @@ import ReactDOM from "react-dom";
 import { createInstance } from "@featurevisor/sdk";
 import { FeaturevisorProvider } from "@featurevisor/react";
 
-const sdk = createInstance({
+const f = createInstance({
   datafileUrl: "https://cdn.yoursite.com/datafile.json"
 });
 
 ReactDOM.render(
-  <FeaturevisorProvider sdk={sdk}>
+  <FeaturevisorProvider instance={f}>
     <App />
   </FeaturevisorProvider>,
   document.getElementById("root")
@@ -143,7 +143,7 @@ import React from "react":
 import { useSdk } from "@featurevisor/react";
 
 function MyComponent(props) {
-  const sdk = useSdk();
+  const f = useSdk();
 
   return <p>...</p>;
 };

--- a/docs/vue.md
+++ b/docs/vue.md
@@ -23,7 +23,7 @@ import { createApp } from "vue";
 import { createInstance } from "@featurevisor/sdk";
 import { setupApp } from "@featurevisor/vue";
 
-const sdk = createInstance({
+const f = createInstance({
   datafileUrl: "https://cdn.yoursite.com/datafile.json"
 });
 
@@ -31,7 +31,7 @@ const app = createApp({
   /* root component options */
 });
 
-setupApp(app, sdk);
+setupApp(app, f);
 ```
 
 This will set up the SDK instance in your Vue application, and make it available in all components later.
@@ -148,7 +148,7 @@ Get the SDK instance:
 <script setup>
 import { useSdk } from "@featurevisor/vue";
 
-const sdk = useSdk();
+const f = useSdk();
 </script>
 
 <template>

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -4,96 +4,11 @@ React components and hooks for Featurevisor.
 
 Visit [https://featurevisor.com/docs/react/](https://featurevisor.com/docs/react/) for more information.
 
-- [Installation](#installation)
-- [API](#api)
-  - [`FeaturevisorProvider`](#featurevisorprovider)
-  - [`useStatus`](#usestatus)
-  - [`useFlag`](#useflag)
-  - [`useVariation`](#usevariation)
-  - [`useVariable`](#usevariable)
-  - [`activateFeature`](#activatefeature)
-  - [`useSdk`](#usesdk)
-
 ## Installation
 
 ```
 $ npm install --save @featurevisor/react
 ```
-
-## API
-
-### `FeaturevisorProvider`
-
-React Provider component for setting SDK instance:
-
-```js
-import React from "react";
-import { createInstance } from "@featurevisor/sdk";
-import { FeaturevisorProvider } from "@featurevisor/react";
-
-const sdk = createInstance({
-  // ...
-});
-
-function Root() {
-  return (
-    <FeaturevisorProvider sdk={sdk}>
-      <App />
-    </FeaturevisorProvider>
-  );
-}
-```
-
-### `useStatus`
-
-> useStatus(): { isReady: boolean }
-
-Hook for checking if Featurevisor SDK is ready.
-
-```js
-import React from "react";
-import { useStatus } from "@featurevisor/react";
-
-function App() {
-  const { isReady } = useStatus();
-
-  if (!isReady) {
-    return <div>Loading...</div>;
-  }
-
-  return <div>Ready!</div>;
-}
-```
-
-### `useFlag`
-
-> useFlag(featureKey, context = {}): boolean
-
-Hook for checking if feature is enabled.
-
-### `useVariation`
-
-> useVariation(featureKey, context = {}): VariationValue | undefined
-
-Hook for getting variation value.
-
-### `useVariable`
-
-> useVariable(featureKey, variableKey, context = {}): VariableValue | undefined
-
-Hook for getting variable value.
-
-### `activateFeature`
-
-> activateFeature(featureKey, context = {}): VariationValue | undefined
-
-Hook for activating feature.
-
-### `useSdk`
-
-> useSdk(): FeaturevisorInstance
-
-Hook for getting Featurevisor SDK instance.
 
 ## License <!-- omit in toc -->
 

--- a/packages/react/src/FeaturevisorProvider.tsx
+++ b/packages/react/src/FeaturevisorProvider.tsx
@@ -4,12 +4,14 @@ import { FeaturevisorInstance } from "@featurevisor/sdk";
 import { FeaturevisorContext } from "./FeaturevisorContext";
 
 export interface FeaturevisorProviderProps {
-  sdk: FeaturevisorInstance;
+  instance: FeaturevisorInstance;
   children: React.ReactNode;
 }
 
 export function FeaturevisorProvider(props: FeaturevisorProviderProps) {
   return (
-    <FeaturevisorContext.Provider value={props.sdk}>{props.children}</FeaturevisorContext.Provider>
+    <FeaturevisorContext.Provider value={props.instance}>
+      {props.children}
+    </FeaturevisorContext.Provider>
   );
 }

--- a/packages/react/src/activateFeature.spec.tsx
+++ b/packages/react/src/activateFeature.spec.tsx
@@ -50,7 +50,7 @@ describe("react: activateFeature", function () {
     }
 
     render(
-      <FeaturevisorProvider sdk={getNewInstance()}>
+      <FeaturevisorProvider instance={getNewInstance()}>
         <TestComponent />
       </FeaturevisorProvider>,
     );

--- a/packages/react/src/useFlag.spec.tsx
+++ b/packages/react/src/useFlag.spec.tsx
@@ -46,7 +46,7 @@ describe("react: useFlag", function () {
     }
 
     render(
-      <FeaturevisorProvider sdk={getNewInstance()}>
+      <FeaturevisorProvider instance={getNewInstance()}>
         <TestComponent />
       </FeaturevisorProvider>,
     );
@@ -62,7 +62,7 @@ describe("react: useFlag", function () {
     }
 
     render(
-      <FeaturevisorProvider sdk={getNewInstance(false)}>
+      <FeaturevisorProvider instance={getNewInstance(false)}>
         <TestComponent />
       </FeaturevisorProvider>,
     );

--- a/packages/react/src/useSdk.spec.tsx
+++ b/packages/react/src/useSdk.spec.tsx
@@ -52,7 +52,7 @@ describe("react: useSdk", function () {
     }
 
     render(
-      <FeaturevisorProvider sdk={getNewInstance()}>
+      <FeaturevisorProvider instance={getNewInstance()}>
         <TestComponent />
       </FeaturevisorProvider>,
     );

--- a/packages/react/src/useStatus.spec.tsx
+++ b/packages/react/src/useStatus.spec.tsx
@@ -50,7 +50,7 @@ describe("react: useStatus", function () {
     }
 
     render(
-      <FeaturevisorProvider sdk={getNewInstance()}>
+      <FeaturevisorProvider instance={getNewInstance()}>
         <TestComponent />
       </FeaturevisorProvider>,
     );

--- a/packages/react/src/useVariable.spec.tsx
+++ b/packages/react/src/useVariable.spec.tsx
@@ -63,7 +63,7 @@ describe("react: useVariable", function () {
     }
 
     render(
-      <FeaturevisorProvider sdk={getNewInstance()}>
+      <FeaturevisorProvider instance={getNewInstance()}>
         <TestComponent />
       </FeaturevisorProvider>,
     );

--- a/packages/react/src/useVariation.spec.tsx
+++ b/packages/react/src/useVariation.spec.tsx
@@ -50,7 +50,7 @@ describe("react: useVariation", function () {
     }
 
     render(
-      <FeaturevisorProvider sdk={getNewInstance()}>
+      <FeaturevisorProvider instance={getNewInstance()}>
         <TestComponent />
       </FeaturevisorProvider>,
     );

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -4,72 +4,11 @@ Vue.js functions for Featurevisor.
 
 Visit [https://featurevisor.com/docs/vue](https://featurevisor.com/docs/vue) for more information.
 
-- [Installation](#installation)
-- [API](#api)
-  - [`setupApp`](#setupapp)
-  - [`useStatus`](#usestatus)
-  - [`useVariation`](#usevariation)
-  - [`useVariable`](#usevariable)
-  - [`activateFeature`](#activatefeature)
-  - [`useSdk`](#usesdk)
-
 ## Installation
 
 ```
 $ npm install --save @featurevisor/vue
 ```
-
-## API
-
-### `setupApp`
-
-Set up Featurevisor SDK instance in your Vue.js application:
-
-```js
-import { createApp } from "vue";
-import { createInstance } from "@featurevisor/sdk";
-import { setupApp } from "@featurevisor/vue";
-
-const sdk = createInstance({
-  // ...
-});
-
-const app = createApp({
-  /* root component options */
-});
-
-setupApp(app, sdk);
-```
-
-### `useStatus`
-
-> useStatus(): { isReady: boolean }
-
-Function for checking if Featurevisor SDK is ready.
-
-### `useVariation`
-
-> useVariation(featureKey, context = {}): VariationValue | undefined
-
-Function for getting variation value.
-
-### `useVariable`
-
-> useVariable(featureKey, variableKey, context = {}): VariableValue | undefined
-
-Function for getting variable value.
-
-### `activateFeature`
-
-> activateFeature(featureKey, context = {}): VariationValue | undefined
-
-Function for activating feature.
-
-### `useSdk`
-
-> useSdk(): FeaturevisorInstance
-
-Function for getting Featurevisor SDK instance.
 
 ## License <!-- omit in toc -->
 


### PR DESCRIPTION
This affects `@featurevisor/react` package only.

## Before

```js
import React from "react";
import { createInstance } from "@featurevisor/sdk";
import { FeaturevisorProvider } from "@featurevisor/react";

const f = createInstance({
  datafileUrl: "...",
});

function Root() {
  return (
    <FeaturevisorProvider sdk={f}>
      <App />
    </FeaturevisorProvider>
  );
}
```

## After

`sdk` prop changed to `instance`.

```js
import React from "react";
import { createInstance } from "@featurevisor/sdk";
import { FeaturevisorProvider } from "@featurevisor/react";

const f = createInstance({
  datafileUrl: "...",
});

function Root() {
  return (
    <FeaturevisorProvider instance={f}>
      <App />
    </FeaturevisorProvider>
  );
}
```