### PR TITLE
docs: changed sdk variable name to f

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Now you can initialize the SDK with the URL of your datafile, and evaluate your 
 import { createInstance } from "@featurevisor/sdk";
 
 // Initialize the SDK
-const sdk = createInstance({
+const f = createInstance({
   datafileUrl: "https://cdn.yoursite.com/datafile.json",
   onReady: () => console.log("Datafile has been fetched and SDK is ready"),
 });
@@ -163,9 +163,9 @@ const context = {
   country: "nl",
 };
 
-const isEnabled = sdk.isEnabled(featureKey, context);
-const variation = sdk.getVariation(featureKey, context);
-const variable  = sdk.getVariable(featureKey, "someVariableKey", context);
+const isEnabled = f.isEnabled(featureKey, context);
+const variation = f.getVariation(featureKey, context);
+const variable  = f.getVariable(featureKey, "someVariableKey", context);
 ```
 
 Learn more about SDK usage here: [https://featurevisor.com/docs/sdks/](https://featurevisor.com/docs/sdks/).

--- a/docs/code-generation.md
+++ b/docs/code-generation.md
@@ -53,11 +53,11 @@ Initialize Featurevisor SDK as usual, and make your newly created package aware 
 import { createInstance } from "@featurevisor/sdk";
 import { setInstance } from "@yourorg/features";
 
-const sdk = createInstance({
+const f = createInstance({
   datafileUrl: "https://cdn.yoursite.com/datafile.json",
 });
 
-setInstance(sdk);
+setInstance(f);
 ```
 
 Afterwards, you can import your features from the generated package and evaluate their variations and variables.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -4,3 +4,5 @@ description: Example projects with Featurevisor
 ---
 
 You can find example projects on [GitHub](https://github.com/fahad19/featurevisor) in the [examples](https://github.com/fahad19/featurevisor/tree/main/examples) directory.
+
+For SDK integration examples in applications, you can find them in our [GitHub organization](https://github.com/featurevisor) with repos prefixed with []`featurevisor-examples-`](https://github.com/orgs/featurevisor/repositories?q=featurevisor-example&type=all&language=&sort=).

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -207,7 +207,7 @@ const datafileUrl =
   "https://cdn.yoursite.com/production/datafile-tag-all.json";
 const datafileContent = await fetch(datafileUrl).then((res) => res.json());
 
-const sdk = createInstance({
+const f = createInstance({
   datafile: datafileContent,
 });
 ```
@@ -223,7 +223,7 @@ import { createInstance } from "@featurevisor/sdk";
 const datafileUrl =
   "https://cdn.yoursite.com/production/datafile-tag-all.json";
 
-const sdk = createInstance({
+const f = createInstance({
   datafileUrl,
   onReady: function () {
     // datafile has been fetched successfully,
@@ -244,10 +244,10 @@ const context = {
 };
 
 // true or false
-const isBannerEnabled = sdk.isEnabled(featureKey, context);
+const isBannerEnabled = f.isEnabled(featureKey, context);
 
  // `control` or `treatment`
-const bannerVariation = sdk.getVariation(featureKey, context);
+const bannerVariation = f.getVariation(featureKey, context);
 ```
 
 Featurevisor SDK will take care of computing the right variation for you against the given `userId` and `country` attributes as context.

--- a/docs/sdks.md
+++ b/docs/sdks.md
@@ -31,7 +31,7 @@ const datafileUrl =
 
 const datafileContent = await fetch(datafileUrl).then((res) => res.json());
 
-const sdk = createInstance({
+const f = createInstance({
   datafile: datafileContent
 });
 ```
@@ -47,7 +47,7 @@ import { createInstance } from "@featurevisor/sdk";
 const datafileUrl =
   "https://cdn.yoursite.com/production/datafile-tag-all.json";
 
-const sdk = createInstance({
+const f = createInstance({
   datafileUrl: datafileUrl,
 
   onReady: function () {
@@ -60,7 +60,7 @@ const sdk = createInstance({
 If you need to take further control on how the datafile is fetched, you can pass a custom `handleDatafileFetch` function:
 
 ```js
-const sdk = createInstance({
+const f = createInstance({
   datafileUrl: datafileUrl,
 
   onReady: function () {
@@ -100,7 +100,7 @@ const context = {
   country: "nl",
 };
 
-const isEnabled = sdk.isEnabled(featureKey, context);
+const isEnabled = f.isEnabled(featureKey, context);
 ```
 
 ## Getting variations
@@ -114,7 +114,7 @@ const context = {
   country: "nl",
 };
 
-const variation = sdk.getVariation(featureKey, context);
+const variation = f.getVariation(featureKey, context);
 ```
 
 ## Getting variables
@@ -122,7 +122,7 @@ const variation = sdk.getVariation(featureKey, context);
 ```js
 const variableKey = "bgColor";
 
-const bgColorValue = sdk.getVariable(featureKey, variableKey, context);
+const bgColorValue = f.getVariable(featureKey, variableKey, context);
 ```
 
 ## Type specific methods
@@ -132,43 +132,43 @@ Next to generic `getVariable()` methods, there are also type specific methods av
 ### `boolean`
 
 ```js
-sdk.getVariableBoolean(featureKey, variableKey, context);
+f.getVariableBoolean(featureKey, variableKey, context);
 ```
 
 ### `string`
 
 ```js
-sdk.getVariableString(featureKey, variableKey, context);
+f.getVariableString(featureKey, variableKey, context);
 ```
 
 ### `integer`
 
 ```js
-sdk.getVariableInteger(featureKey, variableKey, context);
+f.getVariableInteger(featureKey, variableKey, context);
 ```
 
 ### `double`
 
 ```js
-sdk.getVariableDouble(featureKey, variableKey, context);
+f.getVariableDouble(featureKey, variableKey, context);
 ```
 
 ### `array`
 
 ```js
-sdk.getVariableArray(featureKey, variableKey, context);
+f.getVariableArray(featureKey, variableKey, context);
 ```
 
 ### `object`
 
 ```ts
-sdk.getVariableObject<T>(featureKey, variableKey, context);
+f.getVariableObject<T>(featureKey, variableKey, context);
 ```
 
 ### `json`
 
 ```ts
-sdk.getVariableJSON<T>(featureKey, variableKey, context);
+f.getVariableJSON<T>(featureKey, variableKey, context);
 ```
 
 
@@ -176,10 +176,10 @@ sdk.getVariableJSON<T>(featureKey, variableKey, context);
 
 Activation is useful when you want to track what features and their variations are exposed to your users.
 
-It works the same as `sdk.getVariation()` method, but it will also bubble an event up that you can listen to.
+It works the same as `f.getVariation()` method, but it will also bubble an event up that you can listen to.
 
 ```js
-const sdk = createInstance({
+const f = createInstance({
   datafile: datafileContent,
 
   // handler for activations
@@ -198,7 +198,7 @@ const sdk = createInstance({
   }
 });
 
-const variation = sdk.activate(featureKey, context);
+const variation = f.activate(featureKey, context);
 ```
 
 From the `onActivation` handler, you can send the activation event to your analytics service.
@@ -212,7 +212,7 @@ This helps in cases when you fail to fetch the datafile, but you still wish your
 ```js
 import { createInstance } from "@featurevisor/sdk";
 
-const sdk = createInstance({
+const f = createInstance({
   datafileUrl: "...",
 
   initialFeatures: {
@@ -243,7 +243,7 @@ If you have already identified your user in your application, and know what feat
 ```js
 import { createInstance } from "@featurevisor/sdk";
 
-const sdk = createInstance({
+const f = createInstance({
   datafileUrl: "...",
 
   stickyFeatures: {
@@ -268,7 +268,7 @@ Once initialized with sticky features, the SDK will look for values there first 
 You can also set sticky features after the SDK is initialized:
 
 ```js
-sdk.setStickyFeatures({
+f.setStickyFeatures({
   myFeatureKey: {
     enabled: true,
     variation: "treatment",
@@ -296,7 +296,7 @@ You can customize it further:
 ```js
 import { createInstance, createLogger } from "@featurevisor/sdk";
 
-const sdk = createInstance({
+const f = createInstance({
   // ...
   logger: createLogger({
     levels: [
@@ -312,7 +312,7 @@ const sdk = createInstance({
 You can also set log levels from instance afterwards:
 
 ```js
-sdk.setLogLevels(["error", "warn"]);
+f.setLogLevels(["error", "warn"]);
 ```
 
 ### Handler
@@ -320,7 +320,7 @@ sdk.setLogLevels(["error", "warn"]);
 You can also pass your own log handler, if you do not wish to print the logs to the console:
 
 ```js
-const sdk = createInstance({
+const f = createInstance({
   // ...
   logger: createLogger({
     levels: ["error", "warn", "info", "debug"],
@@ -344,7 +344,7 @@ const defaultContext = {
   country: "nl",
 };
 
-const sdk = createInstance({
+const f = createInstance({
   // ...
   interceptContext: function (context) {
     // return updated context
@@ -369,11 +369,11 @@ It is only possible to refresh datafile in Featurevisor if you are using the `da
 ```js
 import { createInstance } from "@featurevisor/sdk";
 
-const sdk = createInstance({
+const f = createInstance({
   datafileUrl: datafileUrl,
 });
 
-sdk.refresh();
+f.refresh();
 ```
 
 ### Refresh by interval
@@ -383,7 +383,7 @@ If you want to refresh your datafile every X number of seconds, you can pass the
 ```js
 import { createInstance } from "@featurevisor/sdk";
 
-const sdk = createInstance({
+const f = createInstance({
   datafileUrl: datafileUrl,
   refreshInterval: 30, // 30 seconds
 });
@@ -392,13 +392,13 @@ const sdk = createInstance({
 You can stop the interval by calling:
 
 ```js
-sdk.stopRefreshing();
+f.stopRefreshing();
 ```
 
 If you want to resume refreshing:
 
 ```js
-sdk.startRefreshing();
+f.startRefreshing();
 ```
 
 ### Listening for updates
@@ -408,7 +408,7 @@ Every successful refresh will trigger the `onRefresh()` option:
 ```js
 import { createInstance } from "@featurevisor/sdk";
 
-const sdk = createInstance({
+const f = createInstance({
   datafileUrl: datafileUrl,
   onRefresh: function () {
     // datafile has been refreshed successfully
@@ -421,7 +421,7 @@ Not every refresh is going to be of a new datafile version. If you want to know 
 ```js
 import { createInstance } from "@featurevisor/sdk";
 
-const sdk = createInstance({
+const f = createInstance({
   datafileUrl: datafileUrl,
   onUpdate: function () {
     // datafile has been refreshed, and
@@ -443,7 +443,7 @@ You can listen to these events that can occur at various stages in your applicat
 When the SDK is ready to be used if used in an asynchronous way involving `datafileUrl` option:
 
 ```js
-sdk.on("ready", function () {
+f.on("ready", function () {
   // sdk is ready to be used
 });
 ```
@@ -453,7 +453,7 @@ The `ready` event is fired maximum once.
 You can also synchronously check if the SDK is ready:
 
 ```js
-if (sdk.isReady()) {
+if (f.isReady()) {
   // sdk is ready to be used
 }
 ```
@@ -463,7 +463,7 @@ if (sdk.isReady()) {
 When a feature is activated:
 
 ```js
-sdk.on("activation", function (
+f.on("activation", function (
   featureKey,
   variationValue,
   fullContext,
@@ -483,7 +483,7 @@ sdk.on("activation", function (
 When the datafile is refreshed:
 
 ```js
-sdk.on("refresh", function () {
+f.on("refresh", function () {
   // datafile has been refreshed successfully
 });
 ```
@@ -495,7 +495,7 @@ This will only occur if you are using `refreshInterval` option.
 When the datafile is refreshed, and new datafile content is different from the previous one:
 
 ```js
-sdk.on("update", function () {
+f.on("update", function () {
   // datafile has been refreshed, and
   // new datafile content is different from the previous one
 });
@@ -512,9 +512,9 @@ const onReadyHandler = function () {
   // ...
 };
 
-sdk.on("ready", onReadyHandler);
+f.on("ready", onReadyHandler);
 
-sdk.removeListener("ready", onReadyHandler);
+f.removeListener("ready", onReadyHandler);
 ```
 
 ### Remove all listeners
@@ -522,14 +522,14 @@ sdk.removeListener("ready", onReadyHandler);
 If you wish to remove all listeners of any specific event type:
 
 ```js
-sdk.removeAllListeners("ready");
-sdk.removeAllListeners("activation");
+f.removeAllListeners("ready");
+f.removeAllListeners("activation");
 ```
 
 If you wish to remove all active listeners of all event types in one go:
 
 ```js
-sdk.removeAllListeners();
+f.removeAllListeners();
 ```
 
 ## Evaluation details
@@ -538,13 +538,13 @@ Besides logging with debug level enabled, you can also get more details about ho
 
 ```js
 // flag
-const evaluation = sdk.evaluateFlag(featureKey, context);
+const evaluation = f.evaluateFlag(featureKey, context);
 
 // variation
-const evaluation = sdk.evaluateVariation(featureKey, context);
+const evaluation = f.evaluateVariation(featureKey, context);
 
 // variable
-const evaluation = sdk.evaluateVariable(featureKey, variableKey, context);
+const evaluation = f.evaluateVariable(featureKey, variableKey, context);
 ```
 
 The returned object will always contain the following properties:

--- a/docs/tracking/google-analytics.md
+++ b/docs/tracking/google-analytics.md
@@ -31,7 +31,7 @@ The SDK integration snippet below provides a guide on how to push the `featurevi
 ```js
 import { createInstance } from '@featurevisor/sdk';
 
-const sdk = createInstance({
+const f = createInstance({
   datafileUrl: "https://cdn.yoursite.com/datafile.json",
 
   onActivation: function (

--- a/docs/use-cases/entitlements.md
+++ b/docs/use-cases/entitlements.md
@@ -124,7 +124,7 @@ First, initialize the SDK:
 ```js
 import { createInstance } from "@featurevisor/sdk";
 
-const sdk = createInstance({
+const f = createInstance({
   datafileUrl: "https://cdn.yoursite.com/datafile.json",
 });
 ```
@@ -141,7 +141,7 @@ Set sticky features in the SDK for known user:
 ```js
 // we want our known user to be always bucketed
 // into the same plan (variation) as User Profile service suggests
-sdk.setStickyFeatures({
+f.setStickyFeatures({
   plan: {
     enabled: true,
     variation: userProfile.plan,
@@ -159,7 +159,7 @@ const context = {
   country: userProfile.country,
 };
 
-const entitlements = sdk.getVariable(featureKey, variableKey, context);
+const entitlements = f.getVariable(featureKey, variableKey, context);
 ```
 
 The `entitlements` variable will contain an array of all entitlements the user should have against their current plan.
@@ -210,7 +210,7 @@ We can expect our User Profile service to optionally provide the override inform
 We can then use the `overrideEntitlements` field from User Profile and set it as a sticky feature in Featurevisor SDK:
 
 ```js
-sdk.setStickyFeatures({
+f.setStickyFeatures({
   plan: {
     enabled: true,
     variation: userProfile.plan,
@@ -325,7 +325,7 @@ environments:
 This will then require you to evaluate each entitlement separately in your application code using Featurevisor SDKs:
 
 ```js
-const canCreatePosts = sdk.getVariable(
+const canCreatePosts = f.getVariable(
   "plan",
   "canCreatePosts",
   context

--- a/docs/use-cases/experiments.md
+++ b/docs/use-cases/experiments.md
@@ -166,7 +166,7 @@ Then, initialize the SDK in your application:
 ```js
 import { createInstance } from "@featurevisor/sdk";
 
-const sdk = createInstance({
+const f = createInstance({
   datafile: "https://cdn.yoursite.com/datafile.json",
 
   onReady: () => console.log("Datafile has been fetched and SDK is ready")
@@ -183,7 +183,7 @@ const context = {
   deviceType: "iphone"
 };
 
-const ctaButtonVariation = sdk.getVariation(featureKey, context);
+const ctaButtonVariation = f.getVariation(featureKey, context);
 
 if (ctaButtonVariation === "treatment") {
   // render the new CTA button
@@ -285,8 +285,8 @@ In your application, you can access the variables of the `hero` feature as follo
 const featureKey = "hero";
 const context = { deviceId: "device-123" };
 
-const headline = sdk.getVariable(featureKey, "headline", context);
-const ctaButtonText = sdk.getVariable(featureKey, "ctaButtonText", context);
+const headline = f.getVariable(featureKey, "headline", context);
+const ctaButtonText = f.getVariable(featureKey, "ctaButtonText", context);
 ```
 
 Use the values inside your hero element (component) when you render it.
@@ -302,7 +302,7 @@ This is where the `activate()` method of the SDK comes in handy. Before we call 
 ```js
 import { createInstance } from "@featurevisor/sdk";
 
-const sdk = createInstance({
+const f = createInstance({
   datafile: "https://cdn.yoursite.com/datafile.json",
 
   onReady: () => console.log("Datafile has been fetched and SDK is ready"),
@@ -332,7 +332,7 @@ For example, in the case of our CTA button experiment, we can activate the featu
 const featureKey = "hero";
 const context = { deviceId: "device-123" };
 
-sdk.activate(featureKey, context);
+f.activate(featureKey, context);
 ```
 
 ## Mutually exclusive experiments

--- a/docs/use-cases/microfrontends.md
+++ b/docs/use-cases/microfrontends.md
@@ -274,7 +274,7 @@ Once you have [built](/docs/building-datafiles) and [deployed](/docs/deployment)
 // in `products` microfrontend
 import { createInstance } from "@featurevisor/sdk";
 
-const sdk = createInstance({
+const f = createInstance({
   datafileUrl: "https://cdn.yoursite.com/production/datafile-tag-products.json",
 });
 ```
@@ -290,7 +290,7 @@ const context = {
   userId: "...",
 };
 
-const showMarketingBanner = sdk.isEnabled(featureKey, context);
+const showMarketingBanner = f.isEnabled(featureKey, context);
 
 if (showMarketingBanner) {
   // render marketing banner

--- a/docs/use-cases/remote-configuration.md
+++ b/docs/use-cases/remote-configuration.md
@@ -116,7 +116,7 @@ We initialize the SDK first:
 ```js
 import { createInstance } from "@featurevisor/sdk";
 
-const sdk = createInstance({
+const f = createInstance({
   datafileUrl: "https://cdn.yoursite.com/datafile.json",
   onReady: () => console.log("Datafile has been fetched and SDK is ready"),
 });
@@ -129,7 +129,7 @@ const featureKey = "checkout";
 const variableKey = "paymentMethods";
 const context = { userId: "user-123", country: "nl" };
 
-const paymentMethods = sdk.getVariable(
+const paymentMethods = f.getVariable(
   featureKey,
   variableKey,
   context
@@ -195,7 +195,7 @@ Now when we evaluate our features, we will get different results for users in th
 // Users in the Netherlands
 const context = { userId: "user-234", country: "nl" };
 
-const paymentMethods = sdk.getVariable(
+const paymentMethods = f.getVariable(
   featureKey,
   variableKey,
   context
@@ -214,7 +214,7 @@ While rest of the world will still get the same result as before (that is the de
 // Users in the US
 const context = { userId: "user-123", country: "us" };
 
-const paymentMethods = sdk.getVariable(
+const paymentMethods = f.getVariable(
   featureKey,
   variableKey,
   context

--- a/docs/use-cases/testing-in-production.md
+++ b/docs/use-cases/testing-in-production.md
@@ -171,7 +171,7 @@ Initialize the SDK first:
 ```js
 import { createInstance } from '@featurevisor/sdk";
 
-const sdk = createInstance({
+const f = createInstance({
   datafileUrl: "https://cdn.yoursite.com/datafile.json",
 });
 ```
@@ -185,7 +185,7 @@ const context = {
   deviceId: "device-id-1",
 };
 
-const isWishlistEnabled = sdk.isEnabled(featureKey, context);
+const isWishlistEnabled = f.isEnabled(featureKey, context);
 
 if (isWishlistEnabled) {
   // render the wishlist feature


### PR DESCRIPTION
Featurevisor SDK instances are now referred to as `f` instead of `sdk` in the docs.