### PR TITLE
feat: onReady method for SDK as Promise

### DIFF
--- a/docs/sdks.md
+++ b/docs/sdks.md
@@ -458,6 +458,14 @@ if (f.isReady()) {
 }
 ```
 
+For convenience, you can check the readiness with a Promise-based API as well:
+
+```js
+f.onReady().then(function () {
+  // sdk is ready to be used
+});
+```
+
 #### `activation`
 
 When a feature is activated:

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -35,6 +35,7 @@ Visit [https://featurevisor.com/docs/sdks/](https://featurevisor.com/docs/sdks/)
   - [`off`](#off)
   - [`removeListener`](#removelistener)
   - [`removeAllListeners`](#removealllisteners)
+  - [`onReady`](#onready-1)
 
 ## Installation
 
@@ -375,6 +376,12 @@ Alias for `off` method.
 ### `removeAllListeners`
 
 > `removeAllListeners(event?: string): void`
+
+### `onReady`
+
+Resolves the SDK instance with a promise for convenience when it's ready:
+
+> onReady(): Promise<FeaturevisorInstance>
 
 ## License <!-- omit in toc -->
 

--- a/packages/sdk/src/instance.spec.ts
+++ b/packages/sdk/src/instance.spec.ts
@@ -45,6 +45,32 @@ describe("sdk: instance", function () {
     }, 0);
   });
 
+  it("should resolve onReady method as Promise", function (done) {
+    let readyCount = 0;
+
+    const sdk = createInstance({
+      datafile: {
+        schemaVersion: "1",
+        revision: "1.0",
+        features: [],
+        attributes: [],
+        segments: [],
+      },
+      onReady: () => {
+        readyCount += 1;
+      },
+    });
+
+    setTimeout(() => {
+      sdk.onReady().then((f) => {
+        expect(f.isReady()).toEqual(true);
+        expect(readyCount).toEqual(1);
+
+        done();
+      });
+    }, 0);
+  });
+
   it("should configure plain bucketBy", function () {
     let capturedBucketKey = "";
 

--- a/packages/sdk/src/instance.ts
+++ b/packages/sdk/src/instance.ts
@@ -265,6 +265,22 @@ export class FeaturevisorInstance {
     }
   }
 
+  onReady(): Promise<FeaturevisorInstance> {
+    return new Promise((resolve) => {
+      if (this.statuses.ready) {
+        return resolve(this);
+      }
+
+      const cb = () => {
+        this.emitter.removeListener("ready", cb);
+
+        resolve(this);
+      };
+
+      this.emitter.addListener("ready", cb);
+    });
+  }
+
   setDatafile(datafile: DatafileContent | string) {
     try {
       this.datafileReader = new DatafileReader(


### PR DESCRIPTION
For convenience, a new `onReady()` method has been added.

## Usage

```js
import { createInstance } from "@featurevisor/sdk";

const f = createInstance({
  datafileUrl: "https://cdn.yoursite.com/datafile.json",
});

f.onReady(() => console.log("SDK is ready!"));
```

## Why?

I was annoyed wrapping traditional callbacks with Promises when integrating Featurevisor SDK with Next.js when doing server-side rendering.