### PR TITLE
docs: fixed notIn operator example

### DIFF
--- a/docs/segments.md
+++ b/docs/segments.md
@@ -176,7 +176,7 @@ conditions:
 # ...
 conditions:
   - attribute: country
-    operator: in
+    operator: notIn
     value:
       - fr
       - gb


### PR DESCRIPTION
Found this example with incorrect operator while going through the docs, this PR fixes it.