### PR TITLE
feat: use Prettier v2.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "eslint-config-prettier": "^9.0.0",
         "jest": "^29.4.2",
         "lerna": "^6.5.0",
-        "prettier": "^3.0.2",
+        "prettier": "^2.8.8",
         "rimraf": "^4.1.2",
         "ts-jest": "^29.0.5",
         "ts-loader": "^9.4.2",
@@ -3431,23 +3431,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/postcss/"
-      }
-    },
-    "node_modules/@vue/component-compiler-utils/node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/@vue/component-compiler-utils/node_modules/yallist": {
@@ -14886,15 +14869,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.2.tgz",
-      "integrity": "sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
       "bin": {
-        "prettier": "bin/prettier.cjs"
+        "prettier": "bin-prettier.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=10.13.0"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "eslint-config-prettier": "^9.0.0",
     "jest": "^29.4.2",
     "lerna": "^6.5.0",
-    "prettier": "^3.0.2",
+    "prettier": "^2.8.8",
     "rimraf": "^4.1.2",
     "ts-jest": "^29.0.5",
     "ts-loader": "^9.4.2",

--- a/packages/cli/.prettierignore
+++ b/packages/cli/.prettierignore
@@ -1,4 +1,5 @@
 dist/
 lib/
+coverage/
 
 **/*.md

--- a/packages/core/.prettierignore
+++ b/packages/core/.prettierignore
@@ -1,4 +1,5 @@
 dist/
 lib/
+coverage/
 
 **/*.md

--- a/packages/react/.prettierignore
+++ b/packages/react/.prettierignore
@@ -1,4 +1,5 @@
 dist/
 lib/
+coverage/
 
 **/*.md

--- a/packages/sdk/.prettierignore
+++ b/packages/sdk/.prettierignore
@@ -1,4 +1,5 @@
 dist/
 lib/
+coverage/
 
 **/*.md

--- a/packages/site/.prettierignore
+++ b/packages/site/.prettierignore
@@ -1,4 +1,5 @@
 dist/
 lib/
+public/
 
 **/*.md

--- a/packages/site/.prettierignore
+++ b/packages/site/.prettierignore
@@ -1,5 +1,6 @@
 dist/
 lib/
 public/
+coverage/
 
 **/*.md

--- a/packages/types/.prettierignore
+++ b/packages/types/.prettierignore
@@ -1,4 +1,5 @@
 dist/
 lib/
+coverage/
 
 **/*.md

--- a/packages/vue/.prettierignore
+++ b/packages/vue/.prettierignore
@@ -1,4 +1,5 @@
 dist/
 lib/
+coverage/
 
 **/*.md


### PR DESCRIPTION
Used `feat:` to trigger a new publish of all packages, which we couldn't do in last PR merge because of Prettier 3.x issues with Lerna: https://github.com/fahad19/featurevisor/actions/runs/6090195862/job/16524588061#step:10:32